### PR TITLE
Fix param enum for prophet

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -146,6 +146,8 @@ class ProphetHyperoptEstimator(ABC):
             timeout=self._timeout,
             rstate=self._random_state)
 
+        print("best_result:", best_result)
+
         # Retrain the model with all history data.
         model = Prophet(changepoint_prior_scale=best_result.get(ProphetHyperParams.CHANGEPOINT_PRIOR_SCALE.value, 0.05),
                         seasonality_prior_scale=best_result.get(ProphetHyperParams.SEASONALITY_PRIOR_SCALE.value, 10.0),
@@ -159,6 +161,7 @@ class ProphetHyperoptEstimator(ABC):
         model.fit(df)
 
         model_json = model_to_json(model)
+        print("model_json": model_json)
         metrics = trials.best_trial["result"]["metrics"]
 
         results_pd = pd.DataFrame({"model_json": model_json}, index=[0])

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -147,10 +147,10 @@ class ProphetHyperoptEstimator(ABC):
             rstate=self._random_state)
 
         # Retrain the model with all history data.
-        model = Prophet(changepoint_prior_scale=best_result.get(ProphetHyperParams.CHANGEPOINT_PRIOR_SCALE, 0.05),
-                        seasonality_prior_scale=best_result.get(ProphetHyperParams.SEASONALITY_PRIOR_SCALE, 10.0),
-                        holidays_prior_scale=best_result.get(ProphetHyperParams.HOLIDAYS_PRIOR_SCALE, 10.0),
-                        seasonality_mode=seasonality_mode[best_result.get(ProphetHyperParams.SEASONALITY_MODE, 0)],
+        model = Prophet(changepoint_prior_scale=best_result.get(ProphetHyperParams.CHANGEPOINT_PRIOR_SCALE.value, 0.05),
+                        seasonality_prior_scale=best_result.get(ProphetHyperParams.SEASONALITY_PRIOR_SCALE.value, 10.0),
+                        holidays_prior_scale=best_result.get(ProphetHyperParams.HOLIDAYS_PRIOR_SCALE.value, 10.0),
+                        seasonality_mode=seasonality_mode[best_result.get(ProphetHyperParams.SEASONALITY_MODE.value, 0)],
                         interval_width=self._interval_width)
 
         if self._country_holidays:

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -161,7 +161,7 @@ class ProphetHyperoptEstimator(ABC):
         model.fit(df)
 
         model_json = model_to_json(model)
-        print("model_json": model_json)
+        print("model_json:", model_json)
         metrics = trials.best_trial["result"]["metrics"]
 
         results_pd = pd.DataFrame({"model_json": model_json}, index=[0])

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -146,8 +146,6 @@ class ProphetHyperoptEstimator(ABC):
             timeout=self._timeout,
             rstate=self._random_state)
 
-        print("best_result:", best_result)
-
         # Retrain the model with all history data.
         model = Prophet(changepoint_prior_scale=best_result.get(ProphetHyperParams.CHANGEPOINT_PRIOR_SCALE.value, 0.05),
                         seasonality_prior_scale=best_result.get(ProphetHyperParams.SEASONALITY_PRIOR_SCALE.value, 10.0),
@@ -161,7 +159,6 @@ class ProphetHyperoptEstimator(ABC):
         model.fit(df)
 
         model_json = model_to_json(model)
-        print("model_json:", model_json)
         metrics = trials.best_trial["result"]["metrics"]
 
         results_pd = pd.DataFrame({"model_json": model_json}, index=[0])

--- a/runtime/tests/automl_runtime/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/prophet/forecast_test.py
@@ -15,6 +15,7 @@
 #
 
 import unittest
+import json
 import pandas as pd
 from hyperopt import hp
 
@@ -29,7 +30,7 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
             pd.to_datetime(pd.Series(range(num_rows), name="ds").apply(lambda i: f"2020-07-{i+1}")),
             pd.Series(range(num_rows), name="y")
         ], axis=1)
-        self.search_space = {"changepoint_prior_scale": hp.loguniform("changepoint_prior_scale", -6.9, -0.69)}
+        self.search_space = {"changepoint_prior_scale": hp.loguniform("changepoint_prior_scale", -2.3, -0.7)}
 
     def test_sequential_training(self):
         hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
@@ -51,3 +52,7 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
         self.assertAlmostEqual(results["mdape"][0], 0)
         self.assertAlmostEqual(results["smape"][0], 0)
         self.assertAlmostEqual(results["coverage"][0], 1)
+        # check the best result parameter is inside the search space
+        model_json = json.loads(results["model_json"][0])
+        self.assertGreaterEqual(model_json["changepoint_prior_scale"], 0.1)
+        self.assertLessEqual(model_json["changepoint_prior_scale"], 0.5)


### PR DESCRIPTION
Fixes issue reported by https://github.com/databricks/automl/issues/19

## Test
Manual checking [notebook](https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/884158634248354/command/884158634248841). Confirmed the best model is not using default params
