### PR TITLE
[ML-19989] Add `impute_method` parameter in DatetimeTransformer

### DIFF
--- a/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
@@ -71,8 +71,8 @@ class BaseDatetimeTransformer(ABC, TransformerMixin, BaseEstimator):
 
     def fit(self, X, y=None):
         """
-        Do nothing and return the estimator unchanged.
-        This method is just there to implement the usual API and hence work in pipelines.
+        Find the `mean`, `median` or `most_frequent` values of the input data
+        if it is needed for imputation.
         """
         x = self._to_datetime(X.iloc[:, 0])
         if self.impute_method == "mean":

--- a/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
@@ -36,20 +36,24 @@ class BaseDatetimeTransformer(ABC, TransformerMixin, BaseEstimator):
     DAYS_IN_YEAR = 366  # Account for leap years
     WEEKEND_START = 5
 
-    def __init__(self, impute_method=EPOCH):
+    def __init__(self, impute_method=None):
         """Create a `BaseDatetimeTransformer`.
 
         Parameters
         ----------
         impute_method: method used for imputation
         """
+        if not impute_method:
+            impute_method = EPOCH
         self.impute_method = impute_method
         if impute_method not in ("mean", "median", "most_frequent"):
             self.impute_value = pd.to_datetime(self.impute_method)
 
+    @abstractmethod
     def _to_datetime(self, X):
         pass
 
+    @abstractmethod
     def _include_timestamp(self):
         pass
 

--- a/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
@@ -87,6 +87,11 @@ class BaseDatetimeTransformer(ABC, TransformerMixin, BaseEstimator):
         """
         Transform timestamp data to datetime features.
 
+        The transform consists of the following steps:
+        1. convert the input to datetime (using pandas.to_datetime method)
+        2. fill missing values according to `impute_method` passed into the constructor
+        3. generate features
+
         Parameters
         ----------
         X : pd.DataFrame of shape (n_samples, 1)

--- a/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
@@ -62,12 +62,12 @@ class BaseDatetimeTransformer(ABC, TransformerMixin, BaseEstimator):
     @abstractmethod
     def _to_datetime(self, X):
         """Convert the input to datetime objects (essentially floating numbers)."""
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     def _include_timestamp(self):
         """Whether the output should include timestamp features."""
-        pass
+        pass  # pragma: no cover
 
     def fit(self, X, y=None):
         """

--- a/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/base_datetime_transformer.py
@@ -44,7 +44,7 @@ class BaseDatetimeTransformer(ABC, TransformerMixin, BaseEstimator):
         impute_method: method used for imputation
         """
         if not impute_method:
-            impute_method = EPOCH
+            impute_method = self.EPOCH
         self.impute_method = impute_method
         if impute_method not in ("mean", "median", "most_frequent"):
             self.impute_value = pd.to_datetime(self.impute_method)

--- a/runtime/databricks/automl_runtime/sklearn/date_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/date_transformer.py
@@ -23,22 +23,11 @@ class DateTransformer(BaseDatetimeTransformer):
     """
     Generate features from date column.
     """
+    def __init__(self, impute_method=BaseDatetimeTransformer.EPOCH):
+        super().__init__(impute_method)
 
-    def transform(self, X):
-        """
-        Transform date data to datetime features.
+    def _to_datetime(self, X):
+        return X.apply(pd.to_datetime, errors="coerce")
 
-        Parameters
-        ----------
-        X : pd.DataFrame of shape (n_samples, 1)
-            The only column is a date column.
-
-        Returns
-        -------
-        X_tr : pd.DataFrame of shape (n_samples, 10)
-            Transformed features.
-        """
-        X.iloc[:, 0] = X.iloc[:, 0].apply(pd.to_datetime, errors="coerce")
-        X = X.fillna(pd.Timestamp(self.EPOCH))  # Fill NaT with the Unix epoch
-
-        return self._generate_datetime_features(X, include_timestamp=False)
+    def _include_timestamp(self):
+        return False

--- a/runtime/databricks/automl_runtime/sklearn/date_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/date_transformer.py
@@ -23,7 +23,7 @@ class DateTransformer(BaseDatetimeTransformer):
     """
     Generate features from date column.
     """
-    def __init__(self, impute_method=BaseDatetimeTransformer.EPOCH):
+    def __init__(self, impute_method=None):
         super().__init__(impute_method)
 
     def _to_datetime(self, X):

--- a/runtime/databricks/automl_runtime/sklearn/timestamp_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/timestamp_transformer.py
@@ -26,23 +26,12 @@ class TimestampTransformer(BaseDatetimeTransformer):
 
     HOUR_COLUMN_INDEX = 10
 
-    def transform(self, X):
-        """
-        Transform timestamp data to datetime features.
+    def __init__(self, impute_method=BaseDatetimeTransformer.EPOCH):
+        super().__init__(impute_method)
 
-        Parameters
-        ----------
-        X : pd.DataFrame of shape (n_samples, 1)
-            The only column is either a timestamp column or string column with
-            datetime values encoded in ISO 8601 format.
-
-        Returns
-        -------
-        X_tr : pd.DataFrame of shape (n_samples, 13)
-            Transformed features.
-        """
+    def _to_datetime(self, X):
         # Convert column to datetime if data type is string and standardize to UTC
-        X.iloc[:, 0] = X.iloc[:, 0].apply(pd.to_datetime, errors="coerce", utc=True).dt.tz_localize(None)
-        X = X.fillna(pd.Timestamp(self.EPOCH))  # Fill NaT with the Unix epoch
+        return X.apply(pd.to_datetime, errors="coerce", utc=True).dt.tz_localize(None)
 
-        return self._generate_datetime_features(X, include_timestamp=True)
+    def _include_timestamp(self):
+        return True

--- a/runtime/databricks/automl_runtime/sklearn/timestamp_transformer.py
+++ b/runtime/databricks/automl_runtime/sklearn/timestamp_transformer.py
@@ -26,7 +26,7 @@ class TimestampTransformer(BaseDatetimeTransformer):
 
     HOUR_COLUMN_INDEX = 10
 
-    def __init__(self, impute_method=BaseDatetimeTransformer.EPOCH):
+    def __init__(self, impute_method=None):
         super().__init__(impute_method)
 
     def _to_datetime(self, X):


### PR DESCRIPTION
Main change to this PR: add an additional variable, `impute_method` to the datetime transformers to decide how to fill in the missing values. (Without this change, we will fill `1970-01-01`, which will still be the default after this change.)

Secondary change: refactored the code a little to keep common logic in the base class, and use two small abstractmethod override to modify behaviors in subclasses.

The universe counterpart PR is https://github.com/databricks/universe/pull/148207, which is e2e tested in https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/2133117006757276.