### PR TITLE
Add unit for seasonality value

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -67,8 +67,7 @@ class ArimaEstimator:
 
         # Generate cutoffs for cross validation
         cutoffs = generate_cutoffs(history_pd, horizon=self._horizon, unit=self._frequency_unit,
-                                   seasonal_period=max(self._seasonal_periods), seasonal_unit=self._frequency_unit,
-                                   num_folds=self._num_folds)
+                                   num_folds=self._num_folds, seasonal_period=max(self._seasonal_periods))
 
         # Tune seasonal periods
         best_result = None

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -67,7 +67,8 @@ class ArimaEstimator:
 
         # Generate cutoffs for cross validation
         cutoffs = generate_cutoffs(history_pd, horizon=self._horizon, unit=self._frequency_unit,
-                                   seasonal_period=max(self._seasonal_periods), num_folds=self._num_folds)
+                                   seasonal_period=max(self._seasonal_periods), seasonal_unit=self._frequency_unit,
+                                   num_folds=self._num_folds)
 
         # Tune seasonal periods
         best_result = None

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -64,7 +64,7 @@ def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
     # Evaluate Metrics
     seasonal_period_max = max([s["period"] for s in model.seasonalities.values()]) if model.seasonalities else 0
     cutoffs = generate_cutoffs(model.history.reset_index(drop=True), horizon=horizon, unit=frequency,
-                               seasonal_period=seasonal_period_max, num_folds=num_folds)
+                               seasonal_period=seasonal_period_max, seasonal_unit="D", num_folds=num_folds)
     horizon_timedelta = pd.to_timedelta(horizon, unit=frequency)
     df_cv = cross_validation(
         model, horizon=horizon_timedelta, cutoffs=cutoffs, disable_tqdm=True

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -64,7 +64,7 @@ def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
     # Evaluate Metrics
     seasonal_period_max = max([s["period"] for s in model.seasonalities.values()]) if model.seasonalities else 0
     cutoffs = generate_cutoffs(model.history.reset_index(drop=True), horizon=horizon, unit=frequency,
-                               seasonal_period=seasonal_period_max, seasonal_unit="D", num_folds=num_folds)
+                               num_folds=num_folds, seasonal_period=seasonal_period_max, seasonal_unit="D")
     horizon_timedelta = pd.to_timedelta(horizon, unit=frequency)
     df_cv = cross_validation(
         model, horizon=horizon_timedelta, cutoffs=cutoffs, disable_tqdm=True

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -26,7 +26,7 @@ def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
     :param df: pd.DataFrame of the historical data.
     :param horizon: int number of time into the future for forecasting.
     :param unit: frequency of the timeseries, which must be a pandas offset alias.
-    :param seasonal_period: length of the seasonality period in days.
+    :param seasonal_period: length of the seasonality period in given frequency.
     :param seasonal_unit: frequency unit of the seasonal period.
     :param num_folds: int number of cutoffs for cross validation.
     :return: list of pd.Timestamp cutoffs for corss-validation.

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -14,27 +14,30 @@
 # limitations under the License.
 #
 
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 
 
 def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
-                     seasonal_period: int, seasonal_unit: str, num_folds: int) -> List[pd.Timestamp]:
+                     num_folds: int, seasonal_period: int, seasonal_unit: Optional[str] = None) -> List[pd.Timestamp]:
     """
     Generate cutoff times for cross validation with the control of number of folds.
     :param df: pd.DataFrame of the historical data.
     :param horizon: int number of time into the future for forecasting.
-    :param unit: frequency of the timeseries, which must be a pandas offset alias.
-    :param seasonal_period: length of the seasonality period in given frequency.
-    :param seasonal_unit: frequency unit of the seasonal period.
+    :param unit: frequency unit of the time series, which must be a pandas offset alias.
     :param num_folds: int number of cutoffs for cross validation.
-    :return: list of pd.Timestamp cutoffs for corss-validation.
+    :param seasonal_period: length of the seasonality period.
+    :param seasonal_unit: Optional frequency unit for the seasonal period. If not specified, the function will use
+                          the same frequency unit as the time series.
+    :return: list of pd.Timestamp cutoffs for cross-validation.
     """
     period = max(0.5 * horizon, 1)  # avoid empty cutoff buckets
     period_timedelta = pd.to_timedelta(period, unit=unit)
     horizon_timedelta = pd.to_timedelta(horizon, unit=unit)
 
+    if not seasonal_unit:
+        seasonal_unit = unit
     seasonality_timedelta = pd.to_timedelta(seasonal_period, unit=seasonal_unit)
 
     initial = max(3 * horizon_timedelta, seasonality_timedelta)

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -20,13 +20,14 @@ import pandas as pd
 
 
 def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
-                     seasonal_period: int, num_folds: int) -> List[pd.Timestamp]:
+                     seasonal_period: int, seasonal_unit: str, num_folds: int) -> List[pd.Timestamp]:
     """
     Generate cutoff times for cross validation with the control of number of folds.
-    :param df: pd.DataFrame of the historical data
+    :param df: pd.DataFrame of the historical data.
     :param horizon: int number of time into the future for forecasting.
     :param unit: frequency of the timeseries, which must be a pandas offset alias.
-    :param seasonal_period: length of the seasonality period in days
+    :param seasonal_period: length of the seasonality period in days.
+    :param seasonal_unit: frequency unit of the seasonal period.
     :param num_folds: int number of cutoffs for cross validation.
     :return: list of pd.Timestamp cutoffs for corss-validation.
     """
@@ -34,7 +35,7 @@ def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
     period_timedelta = pd.to_timedelta(period, unit=unit)
     horizon_timedelta = pd.to_timedelta(horizon, unit=unit)
 
-    seasonality_timedelta = pd.to_timedelta(seasonal_period, unit=unit)
+    seasonality_timedelta = pd.to_timedelta(seasonal_period, unit=seasonal_unit)
 
     initial = max(3 * horizon_timedelta, seasonality_timedelta)
 

--- a/runtime/tests/automl_runtime/forecast/pmdarima/diagnostics_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/diagnostics_test.py
@@ -33,7 +33,7 @@ class TestDiagnostics(unittest.TestCase):
         ], axis=1)
 
     def test_cross_validation_success(self):
-        cutoffs = generate_cutoffs(self.X, horizon=3, unit="d", seasonal_period=1, num_folds=3)
+        cutoffs = generate_cutoffs(self.X, horizon=3, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=3)
         y_train = self.X[self.X["ds"] <= cutoffs[0]].set_index("ds")
         with StepwiseContext(max_steps=1):
             model = auto_arima(y=y_train, m=1)

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -29,11 +29,11 @@ class TestGenerateCutoffs(unittest.TestCase):
         ).rename_axis("y").reset_index()
 
     def test_generate_cutoffs_success(self):
-        cutoffs = generate_cutoffs(self.X, horizon=7, unit="d", seasonal_period=7, num_folds=3)
+        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", seasonal_period=7, seasonal_unit="D", num_folds=3)
         self.assertEqual([pd.Timestamp('2020-08-19 12:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_success_large_num_folds(self):
-        cutoffs = generate_cutoffs(self.X, horizon=7, unit="d", seasonal_period=1, num_folds=20)
+        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=20)
         self.assertEqual([pd.Timestamp('2020-07-22 12:00:00'),
                           pd.Timestamp('2020-07-26 00:00:00'),
                           pd.Timestamp('2020-07-29 12:00:00'),
@@ -49,7 +49,7 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=30, freq='3d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=1, unit="d", seasonal_period=1, num_folds=5)
+        cutoffs = generate_cutoffs(df, horizon=1, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=5)
         self.assertEqual([pd.Timestamp('2020-09-16 00:00:00'),
                           pd.Timestamp('2020-09-19 00:00:00'),
                           pd.Timestamp('2020-09-22 00:00:00'),
@@ -59,7 +59,7 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=168, freq='h'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=6, unit="h", seasonal_period=24, num_folds=5)
+        cutoffs = generate_cutoffs(df, horizon=6, unit="H", seasonal_period=24, seasonal_unit="H", num_folds=5)
         self.assertEqual([pd.Timestamp('2020-07-07 08:00:00'),
                           pd.Timestamp('2020-07-07 11:00:00'),
                           pd.Timestamp('2020-07-07 14:00:00'),
@@ -69,14 +69,14 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=52, freq='W'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=4, unit="W", seasonal_period=1, num_folds=3)
+        cutoffs = generate_cutoffs(df, horizon=4, unit="W", seasonal_period=1, seasonal_unit="W", num_folds=3)
         self.assertEqual([pd.Timestamp('2021-05-16 00:00:00'), pd.Timestamp('2021-05-30 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_failure_horizon_too_large(self):
         with self.assertRaisesRegex(ValueError, "Less data than horizon after initial window. "
                                                 "Make horizon shorter."):
-            generate_cutoffs(self.X, horizon=20, unit="d", seasonal_period=1, num_folds=3)
+            generate_cutoffs(self.X, horizon=20, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=3)
 
     def test_generate_cutoffs_less_data(self):
         with self.assertRaisesRegex(ValueError, "Less data than horizon."):
-            generate_cutoffs(self.X, horizon=100, unit="days", seasonal_period=1, num_folds=3)
+            generate_cutoffs(self.X, horizon=100, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=3)

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -29,11 +29,11 @@ class TestGenerateCutoffs(unittest.TestCase):
         ).rename_axis("y").reset_index()
 
     def test_generate_cutoffs_success(self):
-        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", seasonal_period=7, seasonal_unit="D", num_folds=3)
+        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", num_folds=3, seasonal_period=7)
         self.assertEqual([pd.Timestamp('2020-08-19 12:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_success_large_num_folds(self):
-        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=20)
+        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", num_folds=20, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2020-07-22 12:00:00'),
                           pd.Timestamp('2020-07-26 00:00:00'),
                           pd.Timestamp('2020-07-29 12:00:00'),
@@ -49,7 +49,7 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=30, freq='3d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=1, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=5)
+        cutoffs = generate_cutoffs(df, horizon=1, unit="D", num_folds=5, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2020-09-16 00:00:00'),
                           pd.Timestamp('2020-09-19 00:00:00'),
                           pd.Timestamp('2020-09-22 00:00:00'),
@@ -59,24 +59,29 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=168, freq='h'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=6, unit="H", seasonal_period=24, seasonal_unit="H", num_folds=5)
-        self.assertEqual([pd.Timestamp('2020-07-07 08:00:00'),
-                          pd.Timestamp('2020-07-07 11:00:00'),
-                          pd.Timestamp('2020-07-07 14:00:00'),
-                          pd.Timestamp('2020-07-07 17:00:00')], cutoffs)
+        expected_cutoffs = [pd.Timestamp('2020-07-07 08:00:00'),
+                            pd.Timestamp('2020-07-07 11:00:00'),
+                            pd.Timestamp('2020-07-07 14:00:00'),
+                            pd.Timestamp('2020-07-07 17:00:00')]
+        cutoffs = generate_cutoffs(df, horizon=6, unit="H", num_folds=5, seasonal_period=24)
+        self.assertEqual(expected_cutoffs, cutoffs)
+
+        cutoffs_different_seasonal_unit = generate_cutoffs(df, horizon=6, unit="H", num_folds=5,
+                                                           seasonal_period=1, seasonal_unit="D")
+        self.assertEqual(expected_cutoffs, cutoffs_different_seasonal_unit)
 
     def test_generate_cutoffs_success_weekly(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=52, freq='W'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=4, unit="W", seasonal_period=1, seasonal_unit="W", num_folds=3)
+        cutoffs = generate_cutoffs(df, horizon=4, unit="W", num_folds=3, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2021-05-16 00:00:00'), pd.Timestamp('2021-05-30 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_failure_horizon_too_large(self):
         with self.assertRaisesRegex(ValueError, "Less data than horizon after initial window. "
                                                 "Make horizon shorter."):
-            generate_cutoffs(self.X, horizon=20, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=3)
+            generate_cutoffs(self.X, horizon=20, unit="D", num_folds=3, seasonal_period=1)
 
     def test_generate_cutoffs_less_data(self):
         with self.assertRaisesRegex(ValueError, "Less data than horizon."):
-            generate_cutoffs(self.X, horizon=100, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=3)
+            generate_cutoffs(self.X, horizon=100, unit="D", num_folds=3, seasonal_period=1)


### PR DESCRIPTION
Prophet's seasonality value is always in days, while the `generate_cutoffs` function previously uses the input frequency to calculate `seasonality_timedelta`. This will cause an incorrect and super large initial period.

This PR fixes the above issue.