### PR TITLE
Add option include_history in predict_timeseries for forecasting model

### DIFF
--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -55,6 +55,9 @@ class TestArimaModel(unittest.TestCase):
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
         self.assertEqual(10, forecast_pd.shape[0])
         pd.testing.assert_series_equal(pd.Series(expected_ds, name='ds'), forecast_pd["ds"])
+        # Test forecast without history data
+        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False)
+        self.assertEqual(len(forecast_future_pd), self.horizon)
 
     def test_predict_success(self):
         test_df = pd.DataFrame({
@@ -123,6 +126,9 @@ class TestMultiSeriesArimaModel(unittest.TestCase):
         expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
         self.assertEqual(20, forecast_pd.shape[0])
+        # Test forecast without history data
+        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False)
+        self.assertEqual(len(forecast_future_pd), 2)
 
     def test_predict_success(self):
         test_df = pd.DataFrame({

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -61,6 +61,8 @@ class TestProphetModel(unittest.TestCase):
         prophet_model.predict(self.X)
         forecast_pd = prophet_model._model_impl.python_model.predict_timeseries()
         np.testing.assert_array_almost_equal(np.array(forecast_pd["yhat"]), self.expected_y)
+        forecast_future_pd = prophet_model._model_impl.python_model.predict_timeseries(include_history=False)
+        self.assertEqual(len(forecast_future_pd), 1)
 
     def test_make_future_dataframe(self):
         for feq_unit in OFFSET_ALIAS_MAP:
@@ -93,6 +95,8 @@ class TestProphetModel(unittest.TestCase):
         # Check model_predict functions
         prophet_model._model_impl.python_model.model_predict(ids)
         prophet_model._model_impl.python_model.predict_timeseries()
+        forecast_future_pd = prophet_model._model_impl.python_model.predict_timeseries(include_history=False)
+        self.assertEqual(len(forecast_future_pd), 2)
 
         # Check predict API
 


### PR DESCRIPTION
Add option include_history so that users can get the predicted data simply if they want.