### PR TITLE
Add test for string type time columns

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -60,7 +60,7 @@ class ArimaEstimator:
         history_pd["ds"] = pd.to_datetime(history_pd["ds"])
 
         # Check if the time has consistent frequency
-        self._validate_ds_freq(df, self._frequency_unit)
+        self._validate_ds_freq(history_pd, self._frequency_unit)
 
         # Impute missing time steps
         history_pd = self._fill_missing_time_steps(history_pd, self._frequency_unit)

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -123,6 +123,7 @@ class ProphetHyperoptEstimator(ABC):
             type) and y
         :return: DataFrame with model json and metrics in cross validation
         """
+        df["ds"] = pd.to_datetime(df["ds"])
 
         seasonality_mode = ["additive", "multiplicative"]
         search_space = self._search_space

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -77,6 +77,15 @@ class TestArimaModel(unittest.TestCase):
         self.assertEqual(2, len(yhat))
         pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
 
+    def test_predict_success_string(self):
+        test_df = pd.DataFrame({
+            "date": ["2020-10-08", "2020-12-10"]
+        })
+        expected_test_df = test_df.copy()
+        yhat = self.arima_model.predict(None, test_df)
+        self.assertEqual(2, len(yhat))
+        pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
+
     def test_predict_failure_unmatched_frequency(self):
         test_df = pd.DataFrame({
             "date": [pd.to_datetime("2020-10-08"), pd.to_datetime("2020-12-10"), pd.to_datetime("2020-11-06")]

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -33,7 +33,7 @@ class TestArimaEstimator(unittest.TestCase):
             pd.to_datetime(pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}")),
             pd.Series(np.random.rand(self.num_rows), name="y")
         ], axis=1)
-        self.df_time_string = pd.concat([
+        self.df_string_time = pd.concat([
             pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}"),
             pd.Series(np.random.rand(self.num_rows), name="y")
         ], axis=1)
@@ -45,7 +45,7 @@ class TestArimaEstimator(unittest.TestCase):
                                          seasonal_periods=[1, 7],
                                          num_folds=2)
 
-        for df in [self.df, self.df_time_string]:
+        for df in [self.df, self.df_string_time]:
             results_pd = arima_estimator.fit(df)
             self.assertIn("smape", results_pd)
             self.assertIn("pickled_model", results_pd)

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -33,6 +33,10 @@ class TestArimaEstimator(unittest.TestCase):
             pd.to_datetime(pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}")),
             pd.Series(np.random.rand(self.num_rows), name="y")
         ], axis=1)
+        self.df_time_string = pd.concat([
+            pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}"),
+            pd.Series(np.random.rand(self.num_rows), name="y")
+        ], axis=1)
 
     def test_fit_success(self):
         arima_estimator = ArimaEstimator(horizon=1,
@@ -41,9 +45,10 @@ class TestArimaEstimator(unittest.TestCase):
                                          seasonal_periods=[1, 7],
                                          num_folds=2)
 
-        results_pd = arima_estimator.fit(self.df)
-        self.assertIn("smape", results_pd)
-        self.assertIn("pickled_model", results_pd)
+        for df in [self.df, self.df_time_string]:
+            results_pd = arima_estimator.fit(df)
+            self.assertIn("smape", results_pd)
+            self.assertIn("pickled_model", results_pd)
 
     def test_fit_success_with_failed_seasonal_periods(self):
         self.df["y"] = range(self.num_rows)  # make pm.auto_arima fail with m=7 because of singular matrices

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -37,6 +37,10 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
             pd.Series(range(self.num_rows), name="ds").apply(lambda i: datetime.date(2020, 7, i + 1)),
             y_series
         ], axis=1)
+        self.df_string_time = pd.concat([
+            pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{i + 1}"),
+            y_series
+        ], axis=1)
         self.search_space = {"changepoint_prior_scale": hp.loguniform("changepoint_prior_scale", -2.3, -0.7)}
 
     def test_sequential_training(self):
@@ -51,7 +55,7 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
                                                   random_state=0,
                                                   is_parallel=False)
 
-        for df in [self.df, self.df_datetime_date]:
+        for df in [self.df, self.df_datetime_date, self.df_string_time]:
             results = hyperopt_estim.fit(df)
             self.assertAlmostEqual(results["mse"][0], 0)
             self.assertAlmostEqual(results["rmse"][0], 0)

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -117,6 +117,17 @@ class TestProphetModel(unittest.TestCase):
         self.assertEqual(2, len(yhat))
         pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
 
+    def test_predict_success_string(self):
+        prophet_model = ProphetModel(self.model_json, 1, "d", "ds")
+        test_df = pd.DataFrame({
+            "ds": ["2020-10-08", "2020-12-10"]
+        })
+        expected_test_df = test_df.copy()
+        yhat = prophet_model.predict(None, test_df)
+        self.assertEqual(2, len(yhat))
+        pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
+
+
     def test_validate_predict_cols(self):
         prophet_model = ProphetModel(self.model_json, 1, "d", "time")
         test_df = pd.DataFrame({


### PR DESCRIPTION
- Fix a bug in pmdarima/training.py
- Add test for string type time column in training and inference for pmdarima and prophet.