### PR TITLE
Set validation_horizon to avoid errors when generating cutoffs for cross-validation

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -71,8 +71,6 @@ class ArimaEstimator:
         # Tune seasonal periods
         best_result = None
         best_metric = float("inf")
-        all_validation_horizons = dict()
-        all_cutoffs = dict()
         for m in self._seasonal_periods:
             try:
                 # this check mirrors the the default behavior by prophet
@@ -91,10 +89,8 @@ class ArimaEstimator:
                     unit=self._frequency_unit,
                     num_folds=self._num_folds,
                 )
-                all_validation_horizons[m] = validation_horizon
-                all_cutoffs[m] = cutoffs
 
-                result = self._fit_predict(history_pd, cutoffs, m, self._max_steps)
+                result = self._fit_predict(history_pd, cutoffs=cutoffs, seasonal_period=m, max_steps=self._max_steps)
                 metric = result["metrics"]["smape"]
                 if metric < best_metric:
                     best_result = result
@@ -107,9 +103,6 @@ class ArimaEstimator:
 
         results_pd = pd.DataFrame(best_result["metrics"], index=[0])
         results_pd["pickled_model"] = pickle.dumps(best_result["model"])
-        results_pd._validation_horizons = all_validation_horizons
-        results_pd._cutoffs = all_cutoffs
-
         return results_pd
 
     @staticmethod

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -24,8 +24,7 @@ from pmdarima.arima import StepwiseContext
 from prophet.diagnostics import performance_metrics
 
 from databricks.automl_runtime.forecast.pmdarima.diagnostics import cross_validation
-from databricks.automl_runtime.forecast.utils import generate_cutoffs
-from databricks.automl_runtime.forecast import OFFSET_ALIAS_MAP
+from databricks.automl_runtime.forecast import utils, OFFSET_ALIAS_MAP
 
 
 class ArimaEstimator:
@@ -39,7 +38,7 @@ class ArimaEstimator:
         :param horizon: Number of periods to forecast forward
         :param frequency_unit: Frequency of the time series
         :param metric: Metric that will be optimized across trials
-        :param seasonal_periods: A list of seasonal periods for tuning.
+        :param seasonal_periods: A list of seasonal periods for tuning. Units are frequency_unit.
         :param num_folds: Number of folds for cross validation
         :param max_steps: Max steps for stepwise auto_arima
         """
@@ -50,7 +49,7 @@ class ArimaEstimator:
         self._num_folds = num_folds
         self._max_steps = max_steps
 
-    def fit(self, df: pd.DataFrame) -> pd.DataFrame:
+    def fit(self, df: pd.DataFrame, cutoffs: Optional[List[pd.Timestamp]] = None) -> pd.DataFrame:
         """
         Fit the ARIMA model with tuning of seasonal period m and with pmdarima.auto_arima.
         :param df: A pd.DataFrame containing the history data. Must have columns ds and y.
@@ -65,13 +64,32 @@ class ArimaEstimator:
         # Impute missing time steps
         history_pd = self._fill_missing_time_steps(history_pd, self._frequency_unit)
 
+        history_timedelta = history_pd['ds'].max() - history_pd['ds'].min()
+        timedeltas = self.history['ds'].diff()
+        min_timedelta = timedeltas.iloc[timedeltas.values.nonzero()[0]].min()
+
         # Tune seasonal periods
         best_result = None
         best_metric = float("inf")
         for m in self._seasonal_periods:
             try:
-                cutoffs = generate_cutoffs(history_pd, horizon=self._horizon, unit=self._frequency_unit,
-                                           num_folds=self._num_folds, seasonal_period=m)
+                # this check mirrors the the default behavior by prophet
+                seasonality_timedelta = pd.to_timedelta(m, unit=self._frequency_unit)
+                if history_timedelta < 2 * seasonality_timedelta or min_timedelta >= seasonality_timedelta:
+                    print(f"Skipping seasonal_period={m} ({seasonality_timedelta}). Dataframe timestamps must span at least two seasonality periods, but only spans {history_timedelta}")
+                    continue
+
+                if cutoffs is None:
+                    validation_horizon = utils.get_validation_horizon(df, self._horizon, self._frequency_unit)
+                    cutoffs = utils.generate_cutoffs(
+                        history_pd,
+                        horizon=validation_horizon,
+                        unit=self._frequency_unit,
+                        num_folds=self._num_folds,
+                    )
+                else:
+                    validation_horizon = self._horizon
+
                 result = self._fit_predict(history_pd, cutoffs, m, self._max_steps)
                 metric = result["metrics"]["smape"]
                 if metric < best_metric:

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -67,8 +67,6 @@ class ArimaEstimator:
         history_pd = self._fill_missing_time_steps(history_pd, self._frequency_unit)
 
         history_timedelta = history_pd['ds'].max() - history_pd['ds'].min()
-        timedeltas = history_pd['ds'].diff()
-        min_timedelta = timedeltas.iloc[timedeltas.values.nonzero()[0]].min()
 
         # Tune seasonal periods
         best_result = None

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -173,7 +173,5 @@ class ProphetHyperoptEstimator(ABC):
             else:
                 results_pd[metric] = np.nan
         results_pd["prophet_params"] = str(best_result)
-        results_pd._validation_horizon = validation_horizon
-        results_pd._cutoffs = cutoffs
 
         return results_pd

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -16,7 +16,7 @@
 from abc import ABC
 from enum import Enum
 from functools import partial
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import hyperopt
 import numpy as np
@@ -26,8 +26,7 @@ from prophet.diagnostics import cross_validation, performance_metrics
 from prophet.serialize import model_to_json
 from hyperopt import fmin, Trials, SparkTrials
 
-from databricks.automl_runtime.forecast.utils import generate_cutoffs
-from databricks.automl_runtime.forecast import OFFSET_ALIAS_MAP
+from databricks.automl_runtime.forecast import utils, OFFSET_ALIAS_MAP
 
 
 class ProphetHyperParams(Enum):
@@ -38,7 +37,7 @@ class ProphetHyperParams(Enum):
 
 
 def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
-                         horizon: int, frequency: str, num_folds: int,
+                         horizon: int, frequency: str, cutoffs: List[pd.Timestamp],
                          interval_width: int, primary_metric: str,
                          country_holidays: Optional[str] = None) -> Dict[str, Any]:
     """
@@ -62,9 +61,6 @@ def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
     model.fit(history_pd, iter=200)
 
     # Evaluate Metrics
-    seasonal_period_max = max([s["period"] for s in model.seasonalities.values()]) if model.seasonalities else 0
-    cutoffs = generate_cutoffs(model.history.reset_index(drop=True), horizon=horizon, unit=frequency,
-                               num_folds=num_folds, seasonal_period=seasonal_period_max, seasonal_unit="D")
     horizon_timedelta = pd.to_timedelta(horizon, unit=frequency)
     df_cv = cross_validation(
         model, horizon=horizon_timedelta, cutoffs=cutoffs, disable_tqdm=True
@@ -116,7 +112,7 @@ class ProphetHyperoptEstimator(ABC):
         self._timeout = trial_timeout
         self._is_parallel = is_parallel
 
-    def fit(self, df: pd.DataFrame) -> pd.DataFrame:
+    def fit(self, df: pd.DataFrame, cutoffs: Optional[List[pd.Timestamp]] = None) -> pd.DataFrame:
         """
         Fit the Prophet model with hyperparameter tunings
         :param df: pd.DataFrame containing the history. Must have columns ds (date
@@ -126,11 +122,20 @@ class ProphetHyperoptEstimator(ABC):
         df["ds"] = pd.to_datetime(df["ds"])
 
         seasonality_mode = ["additive", "multiplicative"]
-        search_space = self._search_space
-        algo = self._algo
 
-        train_fn = partial(_prophet_fit_predict, history_pd=df, horizon=self._horizon,
-                           frequency=self._frequency_unit, num_folds=self._num_folds,
+        if cutoffs is None:
+            validation_horizon = utils.get_validation_horizon(df, self._horizon, self._frequency_unit)
+            cutoffs = utils.generate_cutoffs(
+                df.reset_index(drop=True),
+                horizon=validation_horizon,
+                unit=self._frequency_unit,
+                num_folds=self._num_folds,
+            )
+        else:
+            validation_horizon = self._horizon
+
+        train_fn = partial(_prophet_fit_predict, history_pd=df, horizon=validation_horizon,
+                           frequency=self._frequency_unit, cutoffs=cutoffs,
                            interval_width=self._interval_width,
                            primary_metric=self._metric, country_holidays=self._country_holidays)
 
@@ -141,8 +146,8 @@ class ProphetHyperoptEstimator(ABC):
 
         best_result = fmin(
             fn=train_fn,
-            space=search_space,
-            algo=algo,
+            space=self._search_space,
+            algo=self._algo,
             max_evals=self._max_eval,
             trials=trials,
             timeout=self._timeout,

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -29,6 +29,7 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
     MIN_HORIZONS = 4 # minimum number of horizons in the dataframe
     df_timedelta = df["ds"].max() - df["ds"].min()
     horizon_timedelta = pd.to_timedelta(horizon, unit=unit)
+    print(df_timedelta)
 
     if MIN_HORIZONS * horizon_timedelta <= df_timedelta:
         return horizon
@@ -60,12 +61,14 @@ def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
 
     initial = max(3 * horizon_timedelta, seasonality_timedelta)
 
+    print(f"{initial}, {horizon}, {unit}, {num_folds}")
+
     # Last cutoff is "latest date in data - horizon_timedelta" date
     cutoff = df["ds"].max() - horizon_timedelta
     if cutoff < df["ds"].min():
         raise ValueError("Less data than horizon.")
     result = [cutoff]
-    while result[-1] >= min(df["ds"]) + initial and len(result) < num_folds:
+    while result[-1] >= min(df["ds"]) + initial and len(result) <= num_folds:
         cutoff -= period_timedelta
         # If data does not exist in data range (cutoff, cutoff + horizon_timedelta]
         if not (((df["ds"] > cutoff) & (df["ds"] <= cutoff + horizon_timedelta)).any()):

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import logging
 from typing import List, Optional
 
 import pandas as pd
+
+_logger = logging.getLogger(__name__)
 
 def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
     """
@@ -24,6 +26,9 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
     Since the seasonality period is never more than half of the dataframe's timedelta,
     there is no case where seasonality would affect the validation horizon. (This is prophet's default seasonality
     behavior, and we enforce it for ARIMA.)
+    :param df: pd.DataFrame of the historical data
+    :param horizon: int number of time into the future for forecasting
+    :param unit: frequency unit of the time series, which must be a pandas offset alias
     :return: horizon used for validation, in terms of the input `unit`
     """
     MIN_HORIZONS = 4 # minimum number of horizons in the dataframe
@@ -35,6 +40,7 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
     else:
         validation_horizon_timedelta = df_timedelta / MIN_HORIZONS
         validation_horizon = validation_horizon_timedelta // pd.to_timedelta(1, unit=unit)
+        _logger.info(f"Horizon {horizon_timedelta} too long relative to dataframe's timedelta. Validation horizon will be reduced to {validation_horizon_timedelta}.")
         return validation_horizon
 
 def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -29,7 +29,6 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
     MIN_HORIZONS = 4 # minimum number of horizons in the dataframe
     df_timedelta = df["ds"].max() - df["ds"].min()
     horizon_timedelta = pd.to_timedelta(horizon, unit=unit)
-    print(df_timedelta)
 
     if MIN_HORIZONS * horizon_timedelta <= df_timedelta:
         return horizon
@@ -60,8 +59,6 @@ def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
     seasonality_timedelta = pd.to_timedelta(seasonal_period, unit=seasonal_unit)
 
     initial = max(3 * horizon_timedelta, seasonality_timedelta)
-
-    print(f"{initial}, {horizon}, {unit}, {num_folds}")
 
     # Last cutoff is "latest date in data - horizon_timedelta" date
     cutoff = df["ds"].max() - horizon_timedelta

--- a/runtime/environment.txt
+++ b/runtime/environment.txt
@@ -4,11 +4,13 @@
 holidays==0.11.3.1
 hyperopt==0.2.7
 koalas==1.8.1
-mlflow==1.22.0
+mlflow==1.26.0
 numpy==1.20.2
 pandas==1.2.4
 pmdarima==1.8.4
 prophet==1.0.1
+# protobuf 4.21.0 was released on 5/25/2022, but it is not compatible with the latest mlflow
+protobuf==3.20.1
 pyarrow==4.0.0
 scikit-learn==0.24.1
 wrapt==1.12.1

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -16,6 +16,7 @@
 
 import unittest
 import pytest
+from unittest.mock import patch
 
 import pandas as pd
 import numpy as np
@@ -60,23 +61,39 @@ class TestArimaEstimator(unittest.TestCase):
             results_pd = arima_estimator.fit(self.df)
             self.assertIn("Skipping seasonal_period=14 (14 days 00:00:00). Dataframe timestamps must span at least two seasonality periods", cm.output[0])
 
-        self.assertEqual(len(results_pd._validation_horizons), 1)
-        self.assertEqual(len(results_pd._cutoffs), 1)
-        self.assertIn(3, results_pd._validation_horizons)
-        self.assertIn(3, results_pd._cutoffs)
-
-    def test_fit_horizon_truncation(self):
+    @patch("databricks.automl_runtime.forecast.prophet.forecast.utils.generate_cutoffs")
+    def test_fit_horizon_truncation(self, mock_generate_cutoffs):
         period = 2
         arima_estimator = ArimaEstimator(horizon=100,
                                          frequency_unit="d",
                                          metric="smape",
                                          seasonal_periods=[period],
                                          num_folds=2)
-        results_pd = arima_estimator.fit(self.df)
+        try:
+            results_pd = arima_estimator.fit(self.df)
+        except Exception:
+            # expected to throw exception because generate_cutoffs is mocked
+            pass
 
         # self.df spans 22 days, so the valididation_horizon is floor(22/4)=5 days, and only one cutoff is produced
-        self.assertEqual(results_pd._validation_horizons[period], 5)
-        self.assertEqual(len(results_pd._cutoffs[period]), 1)
+        self.assertEqual(mock_generate_cutoffs.call_args_list[0].kwargs["horizon"], 5)
+
+    @patch.object(ArimaEstimator, "_fit_predict")
+    def test_fit_horizon_truncation_one_cutoff(self, mock_fit_predict):
+        period = 2
+        arima_estimator = ArimaEstimator(horizon=100,
+                                         frequency_unit="d",
+                                         metric="smape",
+                                         seasonal_periods=[period],
+                                         num_folds=2)
+        try:
+            results_pd = arima_estimator.fit(self.df)
+        except Exception:
+            # expected to throw exception because generate_cutoffs is mocked
+            pass
+
+        # self.df spans 22 days, so the valididation_horizon is floor(22/4)=5 days, and only one cutoff is produced
+        self.assertEqual(len(mock_fit_predict.call_args_list[0].kwargs["cutoffs"]), 1)
 
     def test_fit_success_with_failed_seasonal_periods(self):
         self.df["y"] = range(self.num_rows)  # make pm.auto_arima fail with m=7 because of singular matrices

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -69,7 +69,7 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
             self.assertLess(results["mape"][0], 1)
             self.assertLess(results["mdape"][0], 1)
             self.assertLess(results["smape"][0], 1)
-            self.assertGreater(results["coverage"][0], 0)
+            self.assertGreaterEqual(results["coverage"][0], 0)
             # check the best result parameter is inside the search space
             model_json = json.loads(results["model_json"][0])
             self.assertGreaterEqual(model_json["changepoint_prior_scale"], 0.1)

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -28,7 +28,7 @@ from databricks.automl_runtime.forecast.prophet.forecast import ProphetHyperoptE
 class TestProphetHyperoptEstimator(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.num_rows = 21
+        self.num_rows = 12
         y_series =  pd.Series(range(self.num_rows), name="y")
         self.df = pd.concat([
             pd.to_datetime(pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{i + 1}")),
@@ -42,10 +42,64 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
             pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{i + 1}"),
             y_series
         ], axis=1)
+        self.df_horizon_truncation = pd.concat([
+            pd.to_datetime(pd.Series(range(21), name="ds").apply(lambda i: f"2020-07-{i + 1}")),
+            y_series
+        ], axis=1)
         self.search_space = {"changepoint_prior_scale": hp.loguniform("changepoint_prior_scale", -2.3, -0.7)}
 
     def test_sequential_training(self):
-        horizon = 1
+        hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
+                                                  frequency_unit="d",
+                                                  metric="smape",
+                                                  interval_width=0.8,
+                                                  country_holidays="US",
+                                                  search_space=self.search_space,
+                                                  num_folds=2,
+                                                  trial_timeout=1000,
+                                                  random_state=0,
+                                                  is_parallel=False)
+
+        for df in [self.df, self.df_datetime_date, self.df_string_time]:
+            results = hyperopt_estim.fit(df)
+            self.assertAlmostEqual(results["mse"][0], 0)
+            self.assertAlmostEqual(results["rmse"][0], 0)
+            self.assertAlmostEqual(results["mae"][0], 0)
+            self.assertAlmostEqual(results["mape"][0], 0)
+            self.assertAlmostEqual(results["mdape"][0], 0)
+            self.assertAlmostEqual(results["smape"][0], 0)
+            self.assertAlmostEqual(results["coverage"][0], 1)
+            # check the best result parameter is inside the search space
+            model_json = json.loads(results["model_json"][0])
+            self.assertGreaterEqual(model_json["changepoint_prior_scale"], 0.1)
+            self.assertLessEqual(model_json["changepoint_prior_scale"], 0.5)
+
+    @patch("databricks.automl_runtime.forecast.prophet.forecast.fmin")
+    @patch("databricks.automl_runtime.forecast.prophet.forecast.Trials")
+    @patch("databricks.automl_runtime.forecast.prophet.forecast.partial")
+    def test_horizon_truncation(self, mock_partial, mock_trials, mock_fmin):
+        hyperopt_estim = ProphetHyperoptEstimator(horizon=100,
+                                                  frequency_unit="d",
+                                                  metric="smape",
+                                                  interval_width=0.8,
+                                                  country_holidays="US",
+                                                  search_space=self.search_space,
+                                                  num_folds=2,
+                                                  trial_timeout=1000,
+                                                  random_state=0,
+                                                  is_parallel=False)
+
+        results = hyperopt_estim.fit(self.df_horizon_truncation)
+        # the dataframe has 21 timestamps, which means the timedelta is 20. So validation horizon is at most 20/4=5
+        kwargs = mock_partial.call_args_list[0].kwargs
+        self.assertEqual(kwargs["horizon"], 5)
+        self.assertEqual(len(kwargs["cutoffs"]), 1)
+
+    @patch("databricks.automl_runtime.forecast.prophet.forecast.fmin")
+    @patch("databricks.automl_runtime.forecast.prophet.forecast.Trials")
+    @patch("databricks.automl_runtime.forecast.prophet.forecast.partial")
+    def test_no_horizon_truncation(self, mock_partial, mock_trials, mock_fmin):
+        horizon = 4
         num_folds = 2
         hyperopt_estim = ProphetHyperoptEstimator(horizon=horizon,
                                                   frequency_unit="d",
@@ -58,38 +112,8 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
                                                   random_state=0,
                                                   is_parallel=False)
 
-        for df in [self.df, self.df_datetime_date, self.df_string_time]:
-            results = hyperopt_estim.fit(df)
-            self.assertEqual(results._validation_horizon, horizon)
-            self.assertEqual(len(results._cutoffs), num_folds)
-
-            self.assertLess(results["mse"][0], 1)
-            self.assertLess(results["rmse"][0], 1)
-            self.assertLess(results["mae"][0], 1)
-            self.assertLess(results["mape"][0], 1)
-            self.assertLess(results["mdape"][0], 1)
-            self.assertLess(results["smape"][0], 1)
-            self.assertGreaterEqual(results["coverage"][0], 0)
-            # check the best result parameter is inside the search space
-            model_json = json.loads(results["model_json"][0])
-            self.assertGreaterEqual(model_json["changepoint_prior_scale"], 0.1)
-            self.assertLessEqual(model_json["changepoint_prior_scale"], 0.5)
-
-    @patch("databricks.automl_runtime.forecast.prophet.forecast.fmin")
-    @patch("databricks.automl_runtime.forecast.prophet.forecast.Trials")
-    def test_horizon_truncation(self, mock_fmin, mock_trials):
-        hyperopt_estim = ProphetHyperoptEstimator(horizon=100,
-                                                  frequency_unit="d",
-                                                  metric="smape",
-                                                  interval_width=0.8,
-                                                  country_holidays="US",
-                                                  search_space=self.search_space,
-                                                  num_folds=2,
-                                                  trial_timeout=1000,
-                                                  random_state=0,
-                                                  is_parallel=False)
-
-        results = hyperopt_estim.fit(self.df)
+        results = hyperopt_estim.fit(self.df_horizon_truncation)
         # the dataframe has 21 timestamps, which means the timedelta is 20. So validation horizon is at most 20/4=5
-        self.assertEqual(results._validation_horizon, 5)
-        self.assertEqual(len(results._cutoffs), 1)
+        kwargs = mock_partial.call_args_list[0].kwargs
+        self.assertEqual(kwargs["horizon"], horizon)
+        self.assertEqual(len(kwargs["cutoffs"]), num_folds)

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -23,7 +23,7 @@ from databricks.automl_runtime.forecast.utils import generate_cutoffs, get_valid
 
 class TestGetValidationHorizon(unittest.TestCase):
 
-    def test_get_validation_horizon_no_truncate(self):
+    def test_no_truncate(self):
         # 5 day horizon is OK for dataframe with 30 days of data
         df = pd.DataFrame(pd.date_range(start="2020-08-01", end="2020-08-30", freq="D"), columns=["ds"])
         validation_horizon = get_validation_horizon(df, 5, "D")
@@ -34,7 +34,7 @@ class TestGetValidationHorizon(unittest.TestCase):
         validation_horizon = get_validation_horizon(df, 2, "W")
         self.assertEqual(validation_horizon, 2)
 
-    def test_get_validation_horizon_truncate(self):
+    def test_truncate(self):
         # for dataframe with 19 days of data, maximum horizon is 4 days
         df = pd.DataFrame(pd.date_range(start="2020-08-01", end="2020-08-20", freq="D"), columns=["ds"])
         validation_horizon = get_validation_horizon(df, 10, "D")
@@ -54,6 +54,12 @@ class TestGetValidationHorizon(unittest.TestCase):
         df = pd.DataFrame(pd.date_range(start="2020-01-01", end="2020-12-31", freq="W"), columns=["ds"])
         validation_horizon = get_validation_horizon(df, 20, "W")
         self.assertEqual(validation_horizon, 12)
+
+    def test_truncate_logs(self):
+        with self.assertLogs(logger="databricks.automl_runtime.forecast", level="INFO") as cm:
+            df = pd.DataFrame(pd.date_range(start="2020-08-01", end="2020-08-20", freq="D"), columns=["ds"])
+            validation_horizon = get_validation_horizon(df, 10, "D")
+            self.assertIn("too long relative to dataframe's timedelta. Validation horizon will be reduced to", cm.output[0])
 
 
 class TestGenerateCutoffs(unittest.TestCase):

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -18,7 +18,42 @@ import unittest
 
 import pandas as pd
 
-from databricks.automl_runtime.forecast.utils import generate_cutoffs
+from databricks.automl_runtime.forecast.utils import generate_cutoffs, get_validation_horizon
+
+
+class TestGetValidationHorizon(unittest.TestCase):
+
+    def test_get_validation_horizon_no_truncate(self):
+        # 5 day horizon is OK for dataframe with 30 days of data
+        df = pd.DataFrame(pd.date_range(start="2020-08-01", end="2020-08-30", freq="D"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 5, "D")
+        self.assertEqual(validation_horizon, 5)
+
+        # 2 week horizon is OK for dataframe with ~12 weeks of data
+        df = pd.DataFrame(pd.date_range(start="2020-01-01", end="2020-04-01", freq="W"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 2, "W")
+        self.assertEqual(validation_horizon, 2)
+
+    def test_get_validation_horizon_truncate(self):
+        # for dataframe with 19 days of data, maximum horizon is 4 days
+        df = pd.DataFrame(pd.date_range(start="2020-08-01", end="2020-08-20", freq="D"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "D")
+        self.assertEqual(validation_horizon, 4)
+
+        # for dataframe with 20 days of data, maximum horizon is 5 days
+        df = pd.DataFrame(pd.date_range(start="2020-08-01", end="2020-08-21", freq="D"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "D")
+        self.assertEqual(validation_horizon, 5)
+
+        # for dataframe with 21 days of data, maximum horizon is 5 days
+        df = pd.DataFrame(pd.date_range(start="2020-08-01", end="2020-08-22", freq="D"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "D")
+        self.assertEqual(validation_horizon, 5)
+
+        # for dataframe with just under one year of data, maximum horizon is 12 weeks
+        df = pd.DataFrame(pd.date_range(start="2020-01-01", end="2020-12-31", freq="W"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 20, "W")
+        self.assertEqual(validation_horizon, 12)
 
 
 class TestGenerateCutoffs(unittest.TestCase):
@@ -30,7 +65,7 @@ class TestGenerateCutoffs(unittest.TestCase):
 
     def test_generate_cutoffs_success(self):
         cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", num_folds=3, seasonal_period=7)
-        self.assertEqual([pd.Timestamp('2020-08-19 12:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
+        self.assertEqual([pd.Timestamp('2020-08-16 00:00:00'), pd.Timestamp('2020-08-19 12:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_success_large_num_folds(self):
         cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", num_folds=20, seasonal_period=1)
@@ -50,7 +85,8 @@ class TestGenerateCutoffs(unittest.TestCase):
             pd.date_range(start="2020-07-01", periods=30, freq='3d'), columns=["ds"]
         ).rename_axis("y").reset_index()
         cutoffs = generate_cutoffs(df, horizon=1, unit="D", num_folds=5, seasonal_period=1)
-        self.assertEqual([pd.Timestamp('2020-09-16 00:00:00'),
+        self.assertEqual([pd.Timestamp('2020-09-13 00:00:00'),
+                          pd.Timestamp('2020-09-16 00:00:00'),
                           pd.Timestamp('2020-09-19 00:00:00'),
                           pd.Timestamp('2020-09-22 00:00:00'),
                           pd.Timestamp('2020-09-25 00:00:00')], cutoffs)
@@ -59,7 +95,8 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=168, freq='h'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        expected_cutoffs = [pd.Timestamp('2020-07-07 08:00:00'),
+        expected_cutoffs = [pd.Timestamp('2020-07-07 05:00:00'),
+                            pd.Timestamp('2020-07-07 08:00:00'),
                             pd.Timestamp('2020-07-07 11:00:00'),
                             pd.Timestamp('2020-07-07 14:00:00'),
                             pd.Timestamp('2020-07-07 17:00:00')]
@@ -75,7 +112,7 @@ class TestGenerateCutoffs(unittest.TestCase):
             pd.date_range(start="2020-07-01", periods=52, freq='W'), columns=["ds"]
         ).rename_axis("y").reset_index()
         cutoffs = generate_cutoffs(df, horizon=4, unit="W", num_folds=3, seasonal_period=1)
-        self.assertEqual([pd.Timestamp('2021-05-16 00:00:00'), pd.Timestamp('2021-05-30 00:00:00')], cutoffs)
+        self.assertEqual([pd.Timestamp('2021-05-02 00:00:00'), pd.Timestamp('2021-05-16 00:00:00'), pd.Timestamp('2021-05-30 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_failure_horizon_too_large(self):
         with self.assertRaisesRegex(ValueError, "Less data than horizon after initial window. "


### PR DESCRIPTION
When the user-provided horizon is too long, prophet and arima models will use a shorter `validation_horizon` to generate cutoffs. This means that they will no longer fail due to errors in the `generate_cutoffs` function, which occur when the horizon is too long relative to the dataset.