### PR TITLE
Fix MultiSeriesProphetModel ts_id key error with one-row dataframe

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -270,9 +270,13 @@ class MultiSeriesProphetModel(ProphetModel):
             model = self.model(df.name)
             if model:
                 predicts = model.predict(df)
+                # We have to explicitly assign the ts_id to avoid KeyError when model_input
+                # only has one row. For multi-rows model_input, the ts_id will be kept as index
+                # after groupby("ts_id").apply(...) and we can retrieve it by reset_index, but
+                # for one-row model_input the ts_id is missing from index.
                 predicts["ts_id"] = df.name
                 return predicts
-        predict_df = test_df.groupby("ts_id").apply(lambda df: model_prediction(df)).reset_index(drop=True)
+        predict_df = test_df.groupby("ts_id").apply(model_prediction).reset_index(drop=True)
         return_df = test_df.merge(predict_df, how="left", on=["ts_id", "ds"])
         return return_df["yhat"]
 

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -269,8 +269,10 @@ class MultiSeriesProphetModel(ProphetModel):
         def model_prediction(df):
             model = self.model(df.name)
             if model:
-                return model.predict(df)
-        predict_df = test_df.groupby("ts_id").apply(lambda df: model_prediction(df)).reset_index()
+                predicts = model.predict(df)
+                predicts["ts_id"] = df.name
+                return predicts
+        predict_df = test_df.groupby("ts_id").apply(lambda df: model_prediction(df)).reset_index(drop=True)
         return_df = test_df.merge(predict_df, how="left", on=["ts_id", "ds"])
         return return_df["yhat"]
 

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -275,3 +275,6 @@ class TestLogModel(unittest.TestCase):
             "id": ["1", "2", "1", "2"],
         })
         loaded_model.predict(test_df)
+
+        # Make sure can make forecasts for one-row dataframe
+        loaded_model.predict(test_df[0:1])

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -150,6 +150,11 @@ class TestMultiSeriesArimaModel(unittest.TestCase):
         self.assertEqual(4, len(yhat))
         pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
 
+    def test_predict_success_one_row(self):
+        test_df = pd.DataFrame({"date": [pd.to_datetime("2020-11-01")], "id": ["1"]})
+        yhat = self.arima_model.predict(None, test_df)
+        self.assertEqual(1, len(yhat))
+
     def test_predict_fail_unseen_id(self):
         test_df = pd.DataFrame({
             "date": [pd.to_datetime("2020-10-05"), pd.to_datetime("2020-10-05"),

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -99,13 +99,16 @@ class TestProphetModel(unittest.TestCase):
         self.assertEqual(len(forecast_future_pd), 2)
 
         # Check predict API
-
         expected_test_df = test_df.copy()
         forecast_y = prophet_model.predict(test_df)
         np.testing.assert_array_almost_equal(np.array(forecast_y),
                                              np.array([10.333333, 10.333333, 11.333333, 11.333333]))
         # Make sure that the input dataframe is unchanged
         assert_frame_equal(test_df, expected_test_df)
+
+        # Check predict API works with one-row dataframe
+        test_df_one_row = test_df[0:1].copy()
+        prophet_model.predict(test_df_one_row)
 
     def test_model_save_and_load_multi_series_multi_ids(self):
         multi_series_model_json = {"1-1": self.model_json, "2-1": self.model_json}
@@ -135,7 +138,6 @@ class TestProphetModel(unittest.TestCase):
         self.assertEqual(len(forecast_future_pd), 2)
 
         # Check predict API
-
         expected_test_df = test_df.copy()
         forecast_y = prophet_model.predict(test_df)
         np.testing.assert_array_almost_equal(np.array(forecast_y),


### PR DESCRIPTION
If we use a loaded `MultiSeriesProphetModel` from mlflow and use a one-row dataframe as input of `predict`, then it will throw a KeyError for `ts_id`. For some reason the `ts_id` is not kept as an index after `test_df.groupby("ts_id").apply(lambda df: model_prediction(df))` when `test_df` only has one row. To fix this, we explicitly assign ts_id in `model_prediction`.