### PR TITLE
Backport bug fixes to 0.2.8

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -76,16 +76,13 @@ class ProphetModel(ForecastModel):
     def model_env(self):
         return PROPHET_CONDA_ENV
 
-    def model(self, id: str) -> Optional[prophet.forecaster.Prophet]:
+    def model(self) -> prophet.forecaster.Prophet:
         """
-        Deserialize one Prophet model from json string based on the id
-        :param id: identity for the Prophet model
+        Deserialize a Prophet model from json string
         :return: Prophet model
         """
         from prophet.serialize import model_from_json
-        if id in self._model_json:
-            return model_from_json(self._model_json[id])
-        return None
+        return model_from_json(self._model_json)
 
     def _make_future_dataframe(self, horizon: int, include_history: bool = True) -> pd.DataFrame:
         """
@@ -165,14 +162,16 @@ class MultiSeriesProphetModel(ProphetModel):
         self._timeseries_starts = timeseries_starts
         self._id_cols = id_cols
 
-    def model(self, id: str) -> prophet.forecaster.Prophet:
+    def model(self, id: str) -> Optional[prophet.forecaster.Prophet]:
         """
         Deserialize one Prophet model from json string based on the id
         :param id: identity for the Prophet model
         :return: Prophet model
         """
         from prophet.serialize import model_from_json
-        return model_from_json(self._model_json[id])
+        if id in self._model_json:
+            return model_from_json(self._model_json[id])
+        return None
 
     def _make_future_dataframe(self, id: str, horizon: int, include_history: bool = True) -> pd.DataFrame:
         """

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.8"  # pragma: no cover
+__version__ = "0.2.8.1"  # pragma: no cover

--- a/runtime/environment.txt
+++ b/runtime/environment.txt
@@ -9,6 +9,8 @@ numpy==1.20.2
 pandas==1.2.4
 pmdarima==1.8.4
 prophet==1.0.1
+# protobuf 4.21.0 was released on 5/25/2022, but it is not compatible with the latest mlflow
+protobuf==3.20.1
 pyarrow==4.0.0
 scikit-learn==0.24.1
 wrapt==1.12.1

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -150,6 +150,11 @@ class TestMultiSeriesArimaModel(unittest.TestCase):
         self.assertEqual(4, len(yhat))
         pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
 
+    def test_predict_success_one_row(self):
+        test_df = pd.DataFrame({"date": [pd.to_datetime("2020-11-01")], "id": ["1"]})
+        yhat = self.arima_model.predict(None, test_df)
+        self.assertEqual(1, len(yhat))
+
     def test_predict_fail_unseen_id(self):
         test_df = pd.DataFrame({
             "date": [pd.to_datetime("2020-10-05"), pd.to_datetime("2020-10-05"),
@@ -275,3 +280,6 @@ class TestLogModel(unittest.TestCase):
             "id": ["1", "2", "1", "2"],
         })
         loaded_model.predict(test_df)
+
+        # Make sure can make forecasts for one-row dataframe
+        loaded_model.predict(test_df[0:1])

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -88,24 +88,72 @@ class TestProphetModel(unittest.TestCase):
 
         # Load the saved model from mlflow
         run_id = run.info.run_id
-        prophet_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
 
         # Check the prediction with the saved model
         ids = pd.DataFrame(multi_series_model_json.keys(), columns=["ts_id"])
         # Check model_predict functions
-        prophet_model._model_impl.python_model.model_predict(ids)
-        prophet_model._model_impl.python_model.predict_timeseries()
-        forecast_future_pd = prophet_model._model_impl.python_model.predict_timeseries(include_history=False)
+        loaded_model._model_impl.python_model.model_predict(ids)
+        loaded_model._model_impl.python_model.predict_timeseries()
+        forecast_future_pd = loaded_model._model_impl.python_model.predict_timeseries(include_history=False)
         self.assertEqual(len(forecast_future_pd), 2)
 
         # Check predict API
-
         expected_test_df = test_df.copy()
-        forecast_y = prophet_model.predict(test_df)
+        forecast_y = loaded_model.predict(test_df)
         np.testing.assert_array_almost_equal(np.array(forecast_y),
                                              np.array([10.333333, 10.333333, 11.333333, 11.333333]))
         # Make sure that the input dataframe is unchanged
         assert_frame_equal(test_df, expected_test_df)
+
+        # Check predict API works with one-row dataframe
+        loaded_model.predict(test_df[0:1])
+
+    def test_model_save_and_load_multi_series_multi_ids(self):
+        multi_series_model_json = {"1-1": self.model_json, "2-1": self.model_json}
+        multi_series_start = {"1-1": pd.Timestamp("2020-07-01"), "2-1": pd.Timestamp("2020-07-01")}
+        prophet_model = MultiSeriesProphetModel(multi_series_model_json, multi_series_start,
+                                                "2020-07-25", 1, "days", "time", ["id1", "id2"])
+        # The id of the last row does not match to any saved model. It should return nan.
+        test_df = pd.DataFrame({
+            "time": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-01"),
+                     pd.to_datetime("2020-11-04"), pd.to_datetime("2020-11-04")],
+            "id1": ["1", "2", "1", "1"],
+            "id2": ["1", "1", "1", "2"],
+        })
+        with mlflow.start_run() as run:
+            mlflow_prophet_log_model(prophet_model, sample_input=test_df)
+
+        # Load the saved model from mlflow
+        run_id = run.info.run_id
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+
+        # Check the prediction with the saved model
+        ids = pd.DataFrame(multi_series_model_json.keys(), columns=["ts_id"])
+        # Check model_predict functions
+        loaded_model._model_impl.python_model.model_predict(ids)
+        loaded_model._model_impl.python_model.predict_timeseries()
+        forecast_future_pd = loaded_model._model_impl.python_model.predict_timeseries(include_history=False)
+        self.assertEqual(len(forecast_future_pd), 2)
+
+        # Check predict API
+        expected_test_df = test_df.copy()
+        forecast_y = loaded_model.predict(test_df)
+        np.testing.assert_array_almost_equal(np.array(forecast_y),
+                                             np.array([10.333333, 10.333333, 11.333333, np.nan]))
+        # Make sure that the input dataframe is unchanged
+        assert_frame_equal(test_df, expected_test_df)
+
+    def test_predict_success_multi_series_one_row(self):
+        multi_series_model_json = {"1": self.model_json, "2": self.model_json}
+        multi_series_start = {"1": pd.Timestamp("2020-07-01"), "2": pd.Timestamp("2020-07-01")}
+        prophet_model = MultiSeriesProphetModel(multi_series_model_json, multi_series_start,
+                                                "2020-07-25", 1, "days", "time", ["id"])
+        test_df = pd.DataFrame({
+            "time": [pd.to_datetime("2020-11-01")], "id": ["1"]
+        })
+        yhat = prophet_model.predict(None, test_df)
+        self.assertEqual(1, len(yhat))
 
     def test_predict_success_datetime_date(self):
         prophet_model = ProphetModel(self.model_json, 1, "d", "ds")


### PR DESCRIPTION
Backports 
* Fix MultiSeriesProphetModel ts_id key error with one-row dataframe https://github.com/databricks/automl/pull/59
* Fix multi id prediction error https://github.com/databricks/automl/pull/58
