### PR TITLE
Backport fixes to 0.2.5

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -59,7 +59,7 @@ class ArimaEstimator:
         history_pd["ds"] = pd.to_datetime(history_pd["ds"])
 
         # Check if the time has consistent frequency
-        self._validate_ds_freq(df, self._frequency_unit)
+        self._validate_ds_freq(history_pd, self._frequency_unit)
 
         # Impute missing time steps
         history_pd = self._fill_missing_time_steps(history_pd, self._frequency_unit)

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 import cloudpickle
 import mlflow
@@ -24,6 +24,8 @@ from databricks.automl_runtime.forecast import OFFSET_ALIAS_MAP
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import infer_signature, ModelSignature
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from databricks.automl_runtime import version
+
 
 PROPHET_CONDA_ENV = {
     "channels": ["conda-forge"],
@@ -32,7 +34,7 @@ PROPHET_CONDA_ENV = {
             "pip": [
                 f"prophet=={prophet.__version__}",
                 f"cloudpickle=={cloudpickle.__version__}",
-                f"databricks-automl-runtime==0.2.5",
+                f"databricks-automl-runtime=={version.__version__}",
             ]
         }
     ],
@@ -160,14 +162,16 @@ class MultiSeriesProphetModel(ProphetModel):
         self._timeseries_starts = timeseries_starts
         self._id_cols = id_cols
 
-    def model(self, id: str) -> prophet.forecaster.Prophet:
+    def model(self, id: str) -> Optional[prophet.forecaster.Prophet]:
         """
         Deserialize one Prophet model from json string based on the id
         :param id: identity for the Prophet model
         :return: Prophet model
         """
         from prophet.serialize import model_from_json
-        return model_from_json(self._model_json[id])
+        if id in self._model_json:
+            return model_from_json(self._model_json[id])
+        return None
 
     def _make_future_dataframe(self, id: str, horizon: int) -> pd.DataFrame:
         """
@@ -250,7 +254,12 @@ class MultiSeriesProphetModel(ProphetModel):
         test_df = model_input.copy()
         test_df["ts_id"] = test_df[self._id_cols].astype(str).agg('-'.join, axis=1)
         test_df.rename(columns={self._time_col: "ds"}, inplace=True)
-        predict_df = test_df.groupby("ts_id").apply(lambda df: self.model(df.name[0]).predict(df)).reset_index()
+
+        def model_prediction(df):
+            model = self.model(df.name)
+            if model:
+                return model.predict(df)
+        predict_df = test_df.groupby("ts_id").apply(lambda df: model_prediction(df)).reset_index()
         return_df = test_df.merge(predict_df, how="left", on=["ts_id", "ds"])
         return return_df["yhat"]
 

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.5.2"  # pragma: no cover
+__version__ = "0.2.5.3"  # pragma: no cover

--- a/runtime/environment.txt
+++ b/runtime/environment.txt
@@ -9,6 +9,8 @@ numpy==1.20.2
 pandas==1.2.4
 pmdarima==1.8.4
 prophet==1.0.1
+# protobuf 4.21.0 was released on 5/25/2022, but it is not compatible with the latest mlflow
+protobuf==3.20.1
 pyarrow==4.0.0
 scikit-learn==0.24.1
 wrapt==1.12.1

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -18,6 +18,7 @@ import unittest
 import pytest
 
 import pandas as pd
+import numpy as np
 import pmdarima as pm
 
 from databricks.automl_runtime.forecast.pmdarima.training import ArimaEstimator

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -32,6 +32,10 @@ class TestArimaEstimator(unittest.TestCase):
             pd.to_datetime(pd.Series(range(num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}")),
             pd.Series(range(num_rows), name="y")
         ], axis=1)
+        self.df_string_time = pd.concat([
+            pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}"),
+            pd.Series(np.random.rand(self.num_rows), name="y")
+        ], axis=1)
 
     def test_fit_success(self):
         arima_estimator = ArimaEstimator(horizon=1,
@@ -40,9 +44,10 @@ class TestArimaEstimator(unittest.TestCase):
                                          seasonal_periods=[1],
                                          num_folds=2)
 
-        results_pd = arima_estimator.fit(self.df)
-        self.assertIn("smape", results_pd)
-        self.assertIn("pickled_model", results_pd)
+        for df in [self.df, self.df_string_time]:
+            results_pd = arima_estimator.fit(df)
+            self.assertIn("smape", results_pd)
+            self.assertIn("pickled_model", results_pd)
 
     def test_fit_failure_inconsistent_frequency(self):
         arima_estimator = ArimaEstimator(horizon=1,

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -34,8 +34,8 @@ class TestArimaEstimator(unittest.TestCase):
             pd.Series(range(num_rows), name="y")
         ], axis=1)
         self.df_string_time = pd.concat([
-            pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}"),
-            pd.Series(np.random.rand(self.num_rows), name="y")
+            pd.Series(range(num_rows), name="ds").apply(lambda i: f"2020-07-{2 * i + 1}"),
+            pd.Series(np.random.rand(num_rows), name="y")
         ], axis=1)
 
     def test_fit_success(self):

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -102,6 +102,42 @@ class TestProphetModel(unittest.TestCase):
         # Make sure that the input dataframe is unchanged
         assert_frame_equal(test_df, expected_test_df)
 
+    def test_model_save_and_load_multi_series_multi_ids(self):
+        multi_series_model_json = {"1-1": self.model_json, "2-1": self.model_json}
+        multi_series_start = {"1-1": pd.Timestamp("2020-07-01"), "2-1": pd.Timestamp("2020-07-01")}
+        prophet_model = MultiSeriesProphetModel(multi_series_model_json, multi_series_start,
+                                                "2020-07-25", 1, "days", "time", ["id1", "id2"])
+        # The id of the last row does not match to any saved model. It should return nan.
+        test_df = pd.DataFrame({
+            "time": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-01"),
+                     pd.to_datetime("2020-11-04"), pd.to_datetime("2020-11-04")],
+            "id1": ["1", "2", "1", "1"],
+            "id2": ["1", "1", "1", "2"],
+        })
+        with mlflow.start_run() as run:
+            mlflow_prophet_log_model(prophet_model, sample_input=test_df)
+
+        # Load the saved model from mlflow
+        run_id = run.info.run_id
+        prophet_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+
+        # Check the prediction with the saved model
+        ids = pd.DataFrame(multi_series_model_json.keys(), columns=["ts_id"])
+        # Check model_predict functions
+        prophet_model._model_impl.python_model.model_predict(ids)
+        prophet_model._model_impl.python_model.predict_timeseries()
+        forecast_future_pd = prophet_model._model_impl.python_model.predict_timeseries(include_history=False)
+        self.assertEqual(len(forecast_future_pd), 2)
+
+        # Check predict API
+
+        expected_test_df = test_df.copy()
+        forecast_y = prophet_model.predict(test_df)
+        np.testing.assert_array_almost_equal(np.array(forecast_y),
+                                             np.array([10.333333, 10.333333, 11.333333, np.nan]))
+        # Make sure that the input dataframe is unchanged
+        assert_frame_equal(test_df, expected_test_df)
+
     def test_validate_predict_cols(self):
         prophet_model = ProphetModel(self.model_json, 1, "d", "time")
         test_df = pd.DataFrame({

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -126,8 +126,6 @@ class TestProphetModel(unittest.TestCase):
         # Check model_predict functions
         prophet_model._model_impl.python_model.model_predict(ids)
         prophet_model._model_impl.python_model.predict_timeseries()
-        forecast_future_pd = prophet_model._model_impl.python_model.predict_timeseries(include_history=False)
-        self.assertEqual(len(forecast_future_pd), 2)
 
         # Check predict API
 


### PR DESCRIPTION
Backports
* fix for prophet multi id predict https://github.com/databricks/automl/pull/58
* fix for string type for pmdarima training validation https://github.com/databricks/automl/pull/49
  * For this one I only manually backport the one-line bug fix instead of cherry-picking because there're too many conflicts for the tests 