### PR TITLE
Allow errors in datetime imputer transform

### DIFF
--- a/runtime/databricks/automl_runtime/sklearn/datetime_imputer.py
+++ b/runtime/databricks/automl_runtime/sklearn/datetime_imputer.py
@@ -68,5 +68,5 @@ class DatetimeImputer(TransformerMixin, BaseEstimator):
         ----------
         X: a pandas DataFrame whose values are date or timestamp.
         """
-        return X.apply(pd.to_datetime).fillna(self.fill_values)
+        return X.apply(pd.to_datetime, errors="coerce").fillna(self.fill_values)
 

--- a/runtime/tests/automl_runtime/sklearn/datetime_imputer_test.py
+++ b/runtime/tests/automl_runtime/sklearn/datetime_imputer_test.py
@@ -49,6 +49,11 @@ class TestDatetimeImputer(unittest.TestCase):
                 DatetimeImputer(strategy="constant", fill_value="1970-01-01").fit_transform(self.get_test_df()),
                 self.get_test_df("1970-01-01", "1970-01-01 00:00").apply(pd.to_datetime))
 
+    def test_imputer_with_conversion_errors(self):
+        assert_frame_equal(
+            DatetimeImputer(strategy="constant", fill_value="1970-01-01").fit_transform(self.get_test_df("null")),
+            self.get_test_df("1970-01-01", "1970-01-01 00:00").apply(pd.to_datetime))
+
     def test_validate_input(self):
         with self.assertRaises(ValueError):
             DatetimeImputer(strategy='foo')


### PR DESCRIPTION
Without explicitly coercing errors if we apply `pd.datetime(..)` it will fail for rows that cannot successfully convert to datetime. Eg: (str('null')