### PR TITLE
Fix the bug for arima model predictions

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -131,8 +131,9 @@ class ArimaModel(AbstractArimaModel):
         """
         horizon = horizon or self._horizon
         X = None
+        time_col = self._time_col if self._time_col in df.columns else "ds"
         if self._exogenous_cols and df is not None:
-            X = (df[df[self._time_col] > self._end_ds].set_index(self._time_col))[self._exogenous_cols]
+            X = (df[df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
         future_pd = self._forecast(horizon, X)
         if include_history:
             in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, X=X)

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -238,8 +238,8 @@ class ArimaModel(AbstractArimaModel):
             start=start_idx,
             end=end_idx,
             return_conf_int=True)
-        periods = calculate_period_differences(start_ds, end_ds, self._frequency) + 1
-        ds_indices = self._get_ds_indices(start_ds=start_ds, periods=periods, frequency=self._frequency)
+        periods = calculate_period_differences(self._start_ds, end_ds, self._frequency) + 1
+        ds_indices = self._get_ds_indices(start_ds=self._start_ds, periods=periods, frequency=self._frequency)[start_idx:]
         in_sample_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds_in_sample})
         in_sample_pd[["yhat_lower", "yhat_upper"]] = conf_in_sample
         return in_sample_pd

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -231,6 +231,8 @@ class ArimaModel(AbstractArimaModel):
             start_ds = self._start_ds
             end_ds = self._end_ds
             start_idx, end_idx = None, None
+        d = self.model().order[1]
+        start_idx = max(start_idx, d)
         preds_in_sample, conf_in_sample = self.model().predict_in_sample(
             X=X,
             start=start_idx,

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -130,7 +130,9 @@ class ArimaModel(AbstractArimaModel):
         :return: A pd.DataFrame with the forecasts and confidence intervals for given horizon_timedelta and history data.
         """
         horizon = horizon or self._horizon
-        X = None if df is None else (df[df[self._time_col] > self._end_ds].set_index(self._time_col))[self._exogenous_cols]
+        X = None
+        if self._exogenous_cols and df is not None:
+            X = (df[df[self._time_col] > self._end_ds].set_index(self._time_col))[self._exogenous_cols]
         future_pd = self._forecast(horizon, X)
         if include_history:
             in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, X=X)

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -131,8 +131,8 @@ class ArimaModel(AbstractArimaModel):
         """
         horizon = horizon or self._horizon
         X = None
-        time_col = self._time_col if self._time_col in df.columns else "ds"
         if self._exogenous_cols and df is not None:
+            time_col = self._time_col if self._time_col in df.columns else "ds"
             X = (df[df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
         future_pd = self._forecast(horizon, X)
         if include_history:

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -337,7 +337,7 @@ class TestMultiSeriesArimaModelWithExogenous(unittest.TestCase):
         self.exogenous_cols = ["x1", "x2"]
         self.X = train_df[self.exogenous_cols]
 
-        model = ARIMA(order=(2, 0, 2), suppress_warnings=True)
+        model = ARIMA(order=(2, 1, 2), suppress_warnings=True)
         model.fit(train_df[["y"]], X=self.X)
         pickled_model = pickle.dumps(model)
         pickled_model_dict = {("1",): pickled_model, ("2",): pickled_model}
@@ -356,7 +356,7 @@ class TestMultiSeriesArimaModelWithExogenous(unittest.TestCase):
         forecast_pd = self.arima_model.predict_timeseries(df=self.df)
         expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
-        self.assertEqual(20, forecast_pd.shape[0])
+        self.assertEqual(18, forecast_pd.shape[0])
         # Test forecast without history data
         forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, df=self.df)
         self.assertEqual(len(forecast_future_pd), 2)


### PR DESCRIPTION
Fix two bugs:

- When input dataframe has change time column name to "ds" in `predict_timeseries`, it will not throw any error.
- Change the start time index when model order is larger which may throw error:
```
In-sample predictions undefined for start={start} when d={d}"
```