### PR TITLE
[ML-42739] Add custom forecasting data splits for automl_runtime

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -35,8 +35,8 @@ class ArimaEstimator:
     """
 
     def __init__(self, horizon: int, frequency_unit: str, metric: str, seasonal_periods: List[int],
-                 num_folds: int = 20, max_steps: int = 150, exogenous_cols: Optional[List[str]] = None,
-                 split_cutoff: Optional[pd.Timestamp] = None) -> None:
+                 num_folds: int = 20, max_steps: int = 150, exogenous_cols: List[str] | None = None,
+                 split_cutoff: pd.Timestamp | None = None) -> None:
         """
         :param horizon: Number of periods to forecast forward
         :param frequency_unit: Frequency of the time series
@@ -46,6 +46,10 @@ class ArimaEstimator:
         :param max_steps: Max steps for stepwise auto_arima
         :param exogenous_cols: Optional list of column names of exogenous variables. If provided, these columns are
         used as additional features in arima model.
+        :param split_cutoff: Optional cutoff specified by user. If provided, 
+        it is the starting point of cutoffs for cross validation.
+        For tuning job, it is the cutoff between train and validate split.
+        For training job, it is the cutoff bewteen validate and test split.
         """
         self._horizon = horizon
         self._frequency_unit = OFFSET_ALIAS_MAP[frequency_unit]

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -15,7 +15,7 @@
 #
 import logging
 import traceback
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 import pickle
@@ -35,8 +35,8 @@ class ArimaEstimator:
     """
 
     def __init__(self, horizon: int, frequency_unit: str, metric: str, seasonal_periods: List[int],
-                 num_folds: int = 20, max_steps: int = 150, exogenous_cols: List[str] | None = None,
-                 split_cutoff: pd.Timestamp | None = None) -> None:
+                 num_folds: int = 20, max_steps: int = 150, exogenous_cols: Optional[List[str]] = None,
+                 split_cutoff: Optional[pd.Timestamp] = None) -> None:
         """
         :param horizon: Number of periods to forecast forward
         :param frequency_unit: Frequency of the time series

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -15,7 +15,7 @@
 #
 import logging
 import traceback
-from typing import List, Optional
+from typing import List
 
 import pandas as pd
 import pickle

--- a/runtime/databricks/automl_runtime/forecast/prophet/diagnostics.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/diagnostics.py
@@ -155,7 +155,6 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
             predicts = pool.gather(predicts)
 
     else:
-        print("find me 1:", df, cutoffs)
         predicts = [
             single_cutoff_forecast(df, model, cutoff, horizon, predict_columns) 
             for cutoff in (tqdm(cutoffs) if not disable_tqdm else cutoffs)

--- a/runtime/databricks/automl_runtime/forecast/prophet/diagnostics.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/diagnostics.py
@@ -155,6 +155,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
             predicts = pool.gather(predicts)
 
     else:
+        print("find me 1:", df, cutoffs)
         predicts = [
             single_cutoff_forecast(df, model, cutoff, horizon, predict_columns) 
             for cutoff in (tqdm(cutoffs) if not disable_tqdm else cutoffs)

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -92,7 +92,7 @@ class ProphetHyperoptEstimator(ABC):
                  max_eval: int = 10, trial_timeout: int = None,
                  random_state: int = 0, is_parallel: bool = True,
                  regressors = None, 
-                 split_cutoff: pd.Timestamp | None = None, **prophet_kwargs) -> None:
+                 split_cutoff: Optional[pd.Timestamp] = None, **prophet_kwargs) -> None:
         """
         Initialization
 

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -70,6 +70,7 @@ def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
     offset_kwarg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[frequency]]
     horizon_offset = pd.DateOffset(**offset_kwarg)*horizon
     # Evaluate Metrics
+    print("find me 2:", history_pd, cutoffs, model)
     df_cv = cross_validation(
         model, horizon=horizon_offset, cutoffs=cutoffs, disable_tqdm=True
     )  # disable tqdm to make it work with ipykernel and reduce the output size

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -92,7 +92,7 @@ class ProphetHyperoptEstimator(ABC):
                  max_eval: int = 10, trial_timeout: int = None,
                  random_state: int = 0, is_parallel: bool = True,
                  regressors = None, 
-                 split_cutoff: Optional[pd.Timestamp] = None, **prophet_kwargs) -> None:
+                 split_cutoff: pd.Timestamp | None = None, **prophet_kwargs) -> None:
         """
         Initialization
 
@@ -109,6 +109,10 @@ class ProphetHyperoptEstimator(ABC):
         :param random_state: random seed for hyperopt
         :param is_parallel: Indicators to decide that whether run hyperopt in 
         :param regressors: list of column names of external regressors
+        :param split_cutoff: Optional cutoff specified by user. If provided, 
+        it is the starting point of cutoffs for cross validation.
+        For tuning job, it is the cutoff between train and validate split.
+        For training job, it is the cutoff bewteen validate and test split.
         :param prophet_kwargs: Optional keyword arguments for Prophet model.
             For information about the parameters see:
             `The Prophet source code <https://github.com/facebook/prophet/blob/master/python/prophet/forecaster.py>`_.

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -70,7 +70,6 @@ def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
     offset_kwarg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[frequency]]
     horizon_offset = pd.DateOffset(**offset_kwarg)*horizon
     # Evaluate Metrics
-    print("find me 2:", history_pd, cutoffs, model)
     df_cv = cross_validation(
         model, horizon=horizon_offset, cutoffs=cutoffs, disable_tqdm=True
     )  # disable tqdm to make it work with ipykernel and reduce the output size

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -91,7 +91,8 @@ class ProphetHyperoptEstimator(ABC):
                  algo=hyperopt.tpe.suggest, num_folds: int = 5,
                  max_eval: int = 10, trial_timeout: int = None,
                  random_state: int = 0, is_parallel: bool = True,
-                 regressors = None, **prophet_kwargs) -> None:
+                 regressors = None, 
+                 split_cutoff: Optional[pd.Timestamp] = None, **prophet_kwargs) -> None:
         """
         Initialization
 
@@ -125,6 +126,7 @@ class ProphetHyperoptEstimator(ABC):
         self._timeout = trial_timeout
         self._is_parallel = is_parallel
         self._regressors = regressors
+        self._split_cutoff = split_cutoff
         self._prophet_kwargs = prophet_kwargs
 
     def fit(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -139,12 +141,20 @@ class ProphetHyperoptEstimator(ABC):
         seasonality_mode = ["additive", "multiplicative"]
 
         validation_horizon = utils.get_validation_horizon(df, self._horizon, self._frequency_unit)
-        cutoffs = utils.generate_cutoffs(
-            df.reset_index(drop=True),
-            horizon=validation_horizon,
-            unit=self._frequency_unit,
-            num_folds=self._num_folds,
-        )
+        if self._split_cutoff:
+            cutoffs = utils.generate_custom_cutoffs(
+                df.reset_index(drop=True),
+                horizon=validation_horizon,
+                unit=self._frequency_unit,
+                split_cutoff=self._split_cutoff
+            )
+        else:
+            cutoffs = utils.generate_cutoffs(
+                df.reset_index(drop=True),
+                horizon=validation_horizon,
+                unit=self._frequency_unit,
+                num_folds=self._num_folds,
+            )
 
         train_fn = partial(_prophet_fit_predict, history_pd=df, horizon=validation_horizon,
                            frequency=self._frequency_unit, cutoffs=cutoffs,

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -215,7 +215,6 @@ def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
             # Next cutoff point is "next date after cutoff in data - horizon_dateoffset"
             closest_date = df[df["ds"] > cutoff].min()["ds"]
             cutoff = closest_date - horizon_dateoffset
-        # else no data left, leave cutoff as is, it will be dropped.
         result.append(cutoff)
         cutoff += period_dateoffset
     return result

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -218,7 +218,6 @@ def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
         # else no data left, leave cutoff as is, it will be dropped.
         result.append(cutoff)
         cutoff += period_dateoffset
-    result = result[:-1]
     return result
 
 def is_quaterly_alias(freq: str):

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -190,14 +190,12 @@ def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
 def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
                      split_cutoff: pd.Timestamp) -> List[pd.Timestamp]:
     """
-    Generate cutoff times for cross validation with the control of number of folds.
+    Generate custom cutoff times for cross validation based on user-specified split cutoff.
+    Period (step size) is 1.
     :param df: pd.DataFrame of the historical data.
     :param horizon: int number of time into the future for forecasting.
     :param unit: frequency unit of the time series, which must be a pandas offset alias.
-    :param num_folds: int number of cutoffs for cross validation.
-    :param seasonal_period: length of the seasonality period.
-    :param seasonal_unit: Optional frequency unit for the seasonal period. If not specified, the function will use
-                          the same frequency unit as the time series.
+    :param split_cutoff: the user-specified cutoff, as the starting point of cutoffs
     :return: list of pd.Timestamp cutoffs for cross-validation.
     """
     period = 1 

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -211,7 +211,7 @@ def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
     max_cutoff = max(df["ds"]) - horizon_dateoffset
     while cutoff <= max_cutoff:
         # If data does not exist in data range (cutoff, cutoff + horizon_dateoffset]
-        if (not (((df["ds"] > cutoff) & (df["ds"] <= cutoff + horizon_dateoffset)).any())) and (cutoff < df["ds"].max()):
+        if (not (((df["ds"] > cutoff) & (df["ds"] <= cutoff + horizon_dateoffset)).any())):
             # Next cutoff point is "next date after cutoff in data - horizon_dateoffset"
             closest_date = df[df["ds"] > cutoff].min()["ds"]
             cutoff = closest_date - horizon_dateoffset

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -207,17 +207,17 @@ def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
 
     # First cutoff is the cutoff bewteen splits
     cutoff = split_cutoff
-    result = [cutoff]
+    result = []
     max_cutoff = max(df["ds"]) - horizon_dateoffset
-    while result[-1] <= max_cutoff:
-        cutoff += period_dateoffset
+    while cutoff <= max_cutoff:
         # If data does not exist in data range (cutoff, cutoff + horizon_dateoffset]
         if (not (((df["ds"] > cutoff) & (df["ds"] <= cutoff + horizon_dateoffset)).any())) and (cutoff < df["ds"].max()):
             # Next cutoff point is "next date after cutoff in data - horizon_dateoffset"
             closest_date = df[df["ds"] > cutoff].min()["ds"]
             cutoff = closest_date - horizon_dateoffset
         # else no data left, leave cutoff as is, it will be dropped.
-        result.append(cutoff) 
+        result.append(cutoff)
+        cutoff += period_dateoffset
     result = result[:-1]
     return result
 

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -200,6 +200,7 @@ def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
     For training job, it is the cutoff bewteen validate and test split.
     :return: list of pd.Timestamp cutoffs for cross-validation.
     """
+    # TODO: [ML-43528] expose period as input.
     period = 1 
     period_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])*period
     horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])*horizon

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20"  # pragma: no cover
+__version__ = "0.2.20.1"  # pragma: no cover

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -72,6 +72,17 @@ class TestArimaEstimator(unittest.TestCase):
         results_pd = arima_estimator.fit(self.df_with_exogenous)
         self.assertIn("smape", results_pd)
         self.assertIn("pickled_model", results_pd)
+    
+    def test_fit_success_with_split_cutoff(self):
+        arima_estimator = ArimaEstimator(horizon=1,
+                                         frequency_unit="d",
+                                         metric="smape",
+                                         seasonal_periods=[1, 7],
+                                         num_folds=2,
+                                         split_cutoff=pd.Timestamp('2020-07-17 00:00:00'))
+        results_pd = arima_estimator.fit(self.df)
+        self.assertIn("smape", results_pd)
+        self.assertIn("pickled_model", results_pd)
 
     def test_fit_skip_too_long_seasonality(self):
         arima_estimator = ArimaEstimator(horizon=1,

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -74,15 +74,18 @@ class TestArimaEstimator(unittest.TestCase):
         self.assertIn("pickled_model", results_pd)
     
     def test_fit_success_with_split_cutoff(self):
-        arima_estimator = ArimaEstimator(horizon=1,
-                                         frequency_unit="d",
-                                         metric="smape",
-                                         seasonal_periods=[1, 7],
-                                         num_folds=2,
-                                         split_cutoff=pd.Timestamp('2020-07-17 00:00:00'))
-        results_pd = arima_estimator.fit(self.df)
-        self.assertIn("smape", results_pd)
-        self.assertIn("pickled_model", results_pd)
+        for freq, df, split_cutoff in [['d', self.df, '2020-07-17 00:00:00'], 
+                         ['d', self.df_string_time, '2020-07-17 00:00:00'], 
+                         ['month', self.df_monthly, '2020-09-07 00:00:00']]:
+            arima_estimator = ArimaEstimator(horizon=1,
+                                            frequency_unit=freq,
+                                            metric="smape",
+                                            seasonal_periods=[1, 7],
+                                            num_folds=2,
+                                            split_cutoff=pd.Timestamp(split_cutoff))
+            results_pd = arima_estimator.fit(df)
+            self.assertIn("smape", results_pd)
+            self.assertIn("pickled_model", results_pd)
 
     def test_fit_skip_too_long_seasonality(self):
         arima_estimator = ArimaEstimator(horizon=1,

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -141,13 +141,13 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
         self.assertListEqual(model_json["extra_regressors"][0], ["f1", "f2"])
 
     def test_training_with_split_cutoff(self):
-        test_spaces = [['D', self.df, '2020-07-10 00:00:00'], 
-                       ['D', self.df_datetime_date, '2020-07-10 00:00:00'], 
-                       ['D', self.df_string_time, '2020-07-10 00:00:00'], 
-                       ['M', self.df_string_monthly_time, '2020-10-15 00:00:00'], 
-                       ['Q', self.df_string_quarterly_time, '2022-04-15 00:00:00'], 
-                       ['Y', self.df_string_annually_time, '2021-01-15 00:00:00']]
-        for freq, df, split_cutoff in test_spaces:
+        test_spaces = [['D', self.df, '2020-07-10 00:00:00', 1e-6], 
+                       ['D', self.df_datetime_date, '2020-07-10 00:00:00', 1e-6], 
+                       ['D', self.df_string_time, '2020-07-10 00:00:00', 1e-6], 
+                       ['M', self.df_string_monthly_time, '2020-10-15 00:00:00', 1e-3], 
+                       ['Q', self.df_string_quarterly_time, '2022-04-15 00:00:00', 1e-1], 
+                       ['Y', self.df_string_annually_time, '2021-01-15 00:00:00', 1e-1]]
+        for freq, df, split_cutoff, delta in test_spaces:
             hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
                                                   frequency_unit=freq,
                                                   metric="smape",
@@ -160,13 +160,13 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
                                                   is_parallel=False,
                                                   split_cutoff=pd.Timestamp(split_cutoff))
             results = hyperopt_estim.fit(df)
-            self.assertAlmostEqual(results["mse"][0], 0, delta=1e-3)
-            self.assertAlmostEqual(results["rmse"][0], 0, delta=1e-6)
-            self.assertAlmostEqual(results["mae"][0], 0, delta=1e-6)
-            self.assertAlmostEqual(results["mape"][0], 0, delta=1e-3)
-            self.assertAlmostEqual(results["mdape"][0], 0, delta=1e-3)
-            self.assertAlmostEqual(results["smape"][0], 0, delta=1e-3)
-            self.assertAlmostEqual(results["coverage"][0], 1, delta=1e-3)
+            self.assertAlmostEqual(results["mse"][0], 0, delta=delta)
+            self.assertAlmostEqual(results["rmse"][0], 0, delta=delta)
+            self.assertAlmostEqual(results["mae"][0], 0, delta=delta)
+            self.assertAlmostEqual(results["mape"][0], 0, delta=delta)
+            self.assertAlmostEqual(results["mdape"][0], 0, delta=delta)
+            self.assertAlmostEqual(results["smape"][0], 0, delta=delta)
+            self.assertAlmostEqual(results["coverage"][0], 1, delta=delta)
             # check the best result parameter is inside the search space
             model_json = json.loads(results["model_json"][0])
             self.assertGreaterEqual(model_json["changepoint_prior_scale"], 0.1)

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -146,7 +146,7 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
                        ['D', self.df_string_time, '2020-07-10 00:00:00', 1e-6], 
                        ['M', self.df_string_monthly_time, '2020-10-15 00:00:00', 1e-1], 
                        ['Q', self.df_string_quarterly_time, '2022-04-15 00:00:00', 1e-1], 
-                       ['Y', self.df_string_annually_time, '2021-01-15 00:00:00', 1e-1]]
+                       ['Y', self.df_string_annually_time, '2021-01-15 00:00:00', 5e-1]]
         for freq, df, split_cutoff, delta in test_spaces:
             hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
                                                   frequency_unit=freq,

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -141,12 +141,12 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
         self.assertListEqual(model_json["extra_regressors"][0], ["f1", "f2"])
 
     def test_training_with_split_cutoff(self):
-        test_spaces = [['D', self.df, '2020-07-09 00:00:00'], 
-                       ['D', self.df_datetime_date, '2020-07-09 00:00:00'], 
-                       ['D', self.df_string_time, '2020-07-09 00:00:00'], 
-                       ['M', self.df_string_monthly_time, '2020-09-15 00:00:00'], 
-                       ['Q', self.df_string_quarterly_time, '2022-01-15 00:00:00'], 
-                       ['Y', self.df_string_annually_time, '2020-01-15 00:00:00']]
+        test_spaces = [['D', self.df, '2020-07-10 00:00:00'], 
+                       ['D', self.df_datetime_date, '2020-07-10 00:00:00'], 
+                       ['D', self.df_string_time, '2020-07-10 00:00:00'], 
+                       ['M', self.df_string_monthly_time, '2020-10-15 00:00:00'], 
+                       ['Q', self.df_string_quarterly_time, '2022-04-15 00:00:00'], 
+                       ['Y', self.df_string_annually_time, '2021-01-15 00:00:00']]
         for freq, df, split_cutoff in test_spaces:
             hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
                                                   frequency_unit=freq,

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -151,7 +151,6 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
                                                   trial_timeout=1000,
                                                   random_state=0,
                                                   is_parallel=False,
-                                                  regressors=["f1", "f2"],
                                                   split_cutoff=pd.Timestamp('2020-07-10 00:00:00'))
 
         for df in [self.df, self.df_datetime_date, self.df_string_time]:

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -141,8 +141,15 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
         self.assertListEqual(model_json["extra_regressors"][0], ["f1", "f2"])
 
     def test_training_with_split_cutoff(self):
-        hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
-                                                  frequency_unit="d",
+        test_spaces = [['D', self.df, '2020-07-09 00:00:00'], 
+                       ['D', self.df_datetime_date, '2020-07-09 00:00:00'], 
+                       ['D', self.df_string_time, '2020-07-09 00:00:00'], 
+                       ['M', self.df_string_monthly_time, '2020-09-15 00:00:00'], 
+                       ['Q', self.df_string_quarterly_time, '2022-01-15 00:00:00'], 
+                       ['Y', self.df_string_annually_time, '2020-01-15 00:00:00']]
+        for freq, df, split_cutoff in test_spaces:
+            hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
+                                                  frequency_unit=freq,
                                                   metric="smape",
                                                   interval_width=0.8,
                                                   country_holidays="US",
@@ -151,9 +158,7 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
                                                   trial_timeout=1000,
                                                   random_state=0,
                                                   is_parallel=False,
-                                                  split_cutoff=pd.Timestamp('2020-07-10 00:00:00'))
-
-        for df in [self.df, self.df_datetime_date, self.df_string_time]:
+                                                  split_cutoff=pd.Timestamp(split_cutoff))
             results = hyperopt_estim.fit(df)
             self.assertAlmostEqual(results["mse"][0], 0)
             self.assertAlmostEqual(results["rmse"][0], 0, delta=1e-6)

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -144,7 +144,7 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
         test_spaces = [['D', self.df, '2020-07-10 00:00:00', 1e-6], 
                        ['D', self.df_datetime_date, '2020-07-10 00:00:00', 1e-6], 
                        ['D', self.df_string_time, '2020-07-10 00:00:00', 1e-6], 
-                       ['M', self.df_string_monthly_time, '2020-10-15 00:00:00', 1e-3], 
+                       ['M', self.df_string_monthly_time, '2020-10-15 00:00:00', 1e-1], 
                        ['Q', self.df_string_quarterly_time, '2022-04-15 00:00:00', 1e-1], 
                        ['Y', self.df_string_annually_time, '2021-01-15 00:00:00', 1e-1]]
         for freq, df, split_cutoff, delta in test_spaces:

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -160,13 +160,13 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
                                                   is_parallel=False,
                                                   split_cutoff=pd.Timestamp(split_cutoff))
             results = hyperopt_estim.fit(df)
-            self.assertAlmostEqual(results["mse"][0], 0)
+            self.assertAlmostEqual(results["mse"][0], 0, delta=1e-3)
             self.assertAlmostEqual(results["rmse"][0], 0, delta=1e-6)
             self.assertAlmostEqual(results["mae"][0], 0, delta=1e-6)
-            self.assertAlmostEqual(results["mape"][0], 0)
-            self.assertAlmostEqual(results["mdape"][0], 0)
-            self.assertAlmostEqual(results["smape"][0], 0)
-            self.assertAlmostEqual(results["coverage"][0], 1)
+            self.assertAlmostEqual(results["mape"][0], 0, delta=1e-3)
+            self.assertAlmostEqual(results["mdape"][0], 0, delta=1e-3)
+            self.assertAlmostEqual(results["smape"][0], 0, delta=1e-3)
+            self.assertAlmostEqual(results["coverage"][0], 1, delta=1e-3)
             # check the best result parameter is inside the search space
             model_json = json.loads(results["model_json"][0])
             self.assertGreaterEqual(model_json["changepoint_prior_scale"], 0.1)

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -202,7 +202,7 @@ class TestTestGenerateCustomCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", end="2020-08-30", freq='2d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-08-26 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=1, unit="D", split_cutoff=pd.Timestamp('2020-08-26 00:00:00'))
         self.assertEqual([pd.Timestamp('2020-08-27 00:00:00'), pd.Timestamp('2020-08-29 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_weekly(self):
@@ -246,8 +246,9 @@ class TestTestGenerateCustomCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=30, freq='9d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2021-03-10 00:00:00'))
-        self.assertEqual([pd.Timestamp('2021-03-10 00:00:00'),
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2021-03-08 00:00:00'))
+        self.assertEqual([pd.Timestamp('2021-03-08 00:00:00'),
+                          pd.Timestamp('2021-03-09 00:00:00'),
                           pd.Timestamp('2021-03-12 00:00:00')], cutoffs)
 
 

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -197,6 +197,13 @@ class TestTestGenerateCustomCutoffs(unittest.TestCase):
         ).rename_axis("y").reset_index()
         cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-08-21 00:00:00'))
         self.assertEqual([pd.Timestamp('2020-08-21 00:00:00'), pd.Timestamp('2020-08-22 00:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
+    
+    def test_generate_custom_cutoffs_success_small_horizon(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01", end="2020-08-30", freq='2d'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-08-26 00:00:00'))
+        self.assertEqual([pd.Timestamp('2020-08-27 00:00:00'), pd.Timestamp('2020-08-29 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_weekly(self):
         df = pd.DataFrame(

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -179,6 +179,7 @@ class TestGenerateCutoffs(unittest.TestCase):
 
 
 class TestTestGenerateCustomCutoffs(unittest.TestCase):
+
     def test_generate_custom_cutoffs_success_hourly(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=168, freq='h'), columns=["ds"]

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -22,7 +22,8 @@ import pandas as pd
 from databricks.automl_runtime.forecast import DATE_OFFSET_KEYWORD_MAP
 from databricks.automl_runtime.forecast.utils import \
     generate_cutoffs, get_validation_horizon, calculate_period_differences, \
-    is_frequency_consistency, make_future_dataframe, make_single_future_dataframe
+    is_frequency_consistency, make_future_dataframe, make_single_future_dataframe, \
+    generate_custom_cutoffs
 
 
 class TestGetValidationHorizon(unittest.TestCase):
@@ -175,6 +176,71 @@ class TestGenerateCutoffs(unittest.TestCase):
         ).rename_axis("y").reset_index()
         cutoffs = generate_cutoffs(df, horizon=1, unit="YS", num_folds=3, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2018-07-14 00:00:00'), pd.Timestamp('2019-07-14 00:00:00'), pd.Timestamp('2020-07-14 00:00:00')], cutoffs)
+
+
+class TestTestGenerateCustomCutoffs(unittest.TestCase):
+    def test_generate_custom_cutoffs_success_hourly(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01", periods=168, freq='h'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        expected_cutoffs = [pd.Timestamp('2020-07-07 13:00:00'),
+                            pd.Timestamp('2020-07-07 14:00:00'),
+                            pd.Timestamp('2020-07-07 15:00:00'),
+                            pd.Timestamp('2020-07-07 16:00:00')]
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="H", split_cutoff=pd.Timestamp('2020-07-07 13:00:00'))
+        self.assertEqual(expected_cutoffs, cutoffs)
+
+    def test_generate_custom_cutoffs_success_daily(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01", end="2020-08-30", freq='d'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-08-21 00:00:00'))
+        self.assertEqual([pd.Timestamp('2020-08-21 12:00:00'), pd.Timestamp('2020-08-22 00:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
+
+    def test_generate_custom_cutoffs_success_weekly(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01", periods=52, freq='W'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="W", split_cutoff=pd.Timestamp('2021-04-25 00:00:00'))
+        self.assertEqual([pd.Timestamp('2021-04-25 00:00:00'), pd.Timestamp('2021-05-02 00:00:00'), pd.Timestamp('2021-05-09 00:00:00')], cutoffs)
+
+    def test_generate_custom_cutoffs_success_monthly(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-01-12", periods=24, freq=pd.DateOffset(months=1)), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="MS", split_cutoff=pd.Timestamp('2021-03-12 00:00:00'))
+        self.assertEqual([pd.Timestamp('2021-03-12 00:00:00'), pd.Timestamp('2021-04-12 00:00:00'), pd.Timestamp('2021-05-12 00:00:00')], cutoffs)
+
+    def test_generate_custom_cutoffs_success_quaterly(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-12", periods=9, freq=pd.DateOffset(months=3)), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="QS", split_cutoff=pd.Timestamp('2021-07-12 00:00:00'))
+        self.assertEqual([pd.Timestamp('2021-07-12 00:00:00'), pd.Timestamp('2022-10-12 00:00:00')], cutoffs)
+
+    def test_generate_custom_cutoffs_success_annualy(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2012-07-14", periods=10, freq=pd.DateOffset(years=1)), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="YS", split_cutoff=pd.Timestamp('2012-07-14 00:00:00'))
+        self.assertEqual([pd.Timestamp('2012-07-14 00:00:00'), pd.Timestamp('2013-07-14 00:00:00'), pd.Timestamp('2014-07-14 00:00:00')], cutoffs)
+
+    def test_generate_custom_cutoffs_success_with_small_gaps(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01", periods=30, freq='3d'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-09-17 00:00:00'))
+        self.assertEqual([pd.Timestamp('2020-09-17 00:00:00'),
+                          pd.Timestamp('2020-09-18 00:00:00'),
+                          pd.Timestamp('2020-09-19 00:00:00')], cutoffs)
+    
+    def test_generate_custom_cutoffs_success_with_large_gaps(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01", periods=30, freq='9d'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2021-03-10 00:00:00'))
+        self.assertEqual([pd.Timestamp('2021-03-10 00:00:00'),
+                          pd.Timestamp('2021-03-12 00:00:00')], cutoffs)
 
 
 class TestCalculatePeriodsAndFrequency(unittest.TestCase):

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -195,7 +195,7 @@ class TestTestGenerateCustomCutoffs(unittest.TestCase):
             pd.date_range(start="2020-07-01", end="2020-08-30", freq='d'), columns=["ds"]
         ).rename_axis("y").reset_index()
         cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-08-21 00:00:00'))
-        self.assertEqual([pd.Timestamp('2020-08-21 12:00:00'), pd.Timestamp('2020-08-22 00:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
+        self.assertEqual([pd.Timestamp('2020-08-21 00:00:00'), pd.Timestamp('2020-08-22 00:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_weekly(self):
         df = pd.DataFrame(
@@ -215,8 +215,8 @@ class TestTestGenerateCustomCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-12", periods=9, freq=pd.DateOffset(months=3)), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="QS", split_cutoff=pd.Timestamp('2021-07-12 00:00:00'))
-        self.assertEqual([pd.Timestamp('2021-07-12 00:00:00'), pd.Timestamp('2022-10-12 00:00:00')], cutoffs)
+        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="QS", split_cutoff=pd.Timestamp('2020-07-12 00:00:00'))
+        self.assertEqual([pd.Timestamp('2020-07-12 00:00:00'), pd.Timestamp('2020-10-12 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_annualy(self):
         df = pd.DataFrame(


### PR DESCRIPTION
This PR enables custom forecasting data splits. There are three main changes.
 - ArimaEstimator
   - add split_cutoff parameter
 - ProphetEstimator
   - add split_cutoff parameter
 - utils.py
   - add generate_custom_cutoff function to generate cutoffs based on given split_cutoff, for cross_validation
- [x] unit tests
- [x] manual e2e tests
- [x] add comments