### PR TITLE
Bump version 0.2.20.2.dev0 -> 0.2.20.2

### DIFF
--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.2.dev0"  # pragma: no cover
+__version__ = "0.2.20.2"  # pragma: no cover


### PR DESCRIPTION
Bump the version to create a new release, which contains basic DeepAR logging functions

Note: the branches 0.2.20.x are all created from MLR 14.3 for runtime compatibility