### PR TITLE
Add back self._target_col from required columns of DeepAR predict()

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -77,7 +77,7 @@ class DeepARModel(ForecastModel):
         :return: predicted pd.DataFrame that starts after the last timestamp in the input dataframe,
                                 and predicts the horizon using the mean of the samples
         """
-        required_cols = [self._time_col]
+        required_cols = [self._target_col, self._time_col]
         if self._id_cols:
             required_cols += self._id_cols
         self._validate_cols(model_input, required_cols)

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.2"  # pragma: no cover
+__version__ = "0.2.20.3.dev"  # pragma: no cover


### PR DESCRIPTION
Adding self._target_col back into DeepAR predict because downstream functions require it to be there.