### PR TITLE
Fill time steps for time-series in DeepAR predict

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -124,10 +124,7 @@ class DeepARModel(ForecastModel):
                                                                         self._frequency,
                                                                         self._id_cols)
 
-        if self._id_cols:
-            test_ds = PandasDataset(model_input_transformed, target=self._target_col)
-        else:
-            test_ds = PandasDataset(model_input_transformed, target=self._target_col)
+        test_ds = PandasDataset(model_input_transformed, target=self._target_col)
 
         forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
         forecast_sample_list = list(forecast_iter)

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -98,7 +98,8 @@ class DeepARModel(ForecastModel):
 
         pred_df = pred_df.rename(columns={'index': self._time_col})
         if self._id_cols:
-            pred_df = pred_df.rename(columns={'item_id': self._id_cols[0]})
+            id_col_name = '-'.join(self._id_cols)
+            pred_df = pred_df.rename(columns={'item_id': id_col_name})
         else:
             pred_df = pred_df.drop(columns='item_id')
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -21,8 +21,7 @@ import pandas as pd
 def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
                                           frequency: str,
                                           id_cols: Optional[List[str]] = None):
-    # TODO (ML-46009): Compare with the ARIMA implementation, and fill
-    #                  the missing time steps for multi-series time series too
+    # TODO (ML-46009): Compare with the ARIMA implementation
 
     total_min, total_max = df[time_col].min(), df[time_col].max()
     new_index_full = pd.date_range(total_min, total_max, freq=frequency)

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -29,9 +29,12 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
     if id_cols is not None:
         df_dict = {}
         for grouped_id, grouped_df in df.groupby(id_cols):
-            ts_id = "-".join([str(x) for x in grouped_id])
-            df_dict[ts_id] = grouped_df.set_index(time_col).sort_index()
-            df_dict[ts_id] = df_dict[ts_id].reindex(new_index_full).drop(id_cols, axis=1)
+            if isinstance(grouped_id, tuple):
+                ts_id = "-".join([str(x) for x in grouped_id])
+            else:
+                ts_id = str(grouped_id)
+            df_dict[ts_id] = (grouped_df.set_index(time_col).sort_index()
+                              .reindex(new_index_full).drop(id_cols, axis=1))
 
         return df_dict
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -21,6 +21,19 @@ import pandas as pd
 def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
                                           frequency: str,
                                           id_cols: Optional[List[str]] = None):
+    """
+    Transform the input dataframe to an acceptable format for the GluonTS library.
+
+    - Set the time column as the index
+    - Impute missing time steps between the min and max time steps
+
+    :param df: the input dataframe that contains time_col
+    :param time_col: time column name
+    :param frequency: the frequency of the time series
+    :param id_cols: the column names of the identity columns for multi-series time series; None for single series
+    :return: single-series - transformed dataframe;
+             multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
+    """
     # TODO (ML-46009): Compare with the ARIMA implementation
 
     total_min, total_max = df[time_col].min(), df[time_col].max()

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2024 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import List, Optional
+
+import pandas as pd
+
+
+def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
+                                          frequency: str,
+                                          id_cols: Optional[List[str]] = None):
+    # TODO (ML-46009): Compare with the ARIMA implementation, and fill
+    #                  the missing time steps for multi-series time series too
+    if id_cols is not None:
+        df = df.set_index(time_col)
+        return df
+
+    df = df.set_index(time_col).sort_index()
+    new_index_full = pd.date_range(df.index.min(), df.index.max(), freq=frequency)
+
+    # Fill in missing time steps between the min and max time steps
+    return df.reindex(new_index_full)

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -34,8 +34,6 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
     :return: single-series - transformed dataframe;
              multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
     """
-    # TODO (ML-46009): Compare with the ARIMA implementation
-
     total_min, total_max = df[time_col].min(), df[time_col].max()
     new_index_full = pd.date_range(total_min, total_max, freq=frequency)
 

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.3.dev"  # pragma: no cover
+__version__ = "0.2.20.3"  # pragma: no cover

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -134,20 +134,20 @@ class TestDeepARModel(unittest.TestCase):
             id_cols=[id_col],
         )
 
-        num_rows = 10
+        num_rows_per_ts = 10
         sample_input_base = pd.concat(
             [
                 pd.to_datetime(
-                    pd.Series(range(num_rows), name=time_col).apply(
+                    pd.Series(range(num_rows_per_ts), name=time_col).apply(
                         lambda i: f"2020-10-{3 * i + 1}"
                     )
                 ),
-                pd.Series(range(num_rows), name=target_col),
+                pd.Series(range(num_rows_per_ts), name=target_col),
             ],
             axis=1,
         )
         sample_input = pd.concat([sample_input_base.copy(), sample_input_base.copy()], ignore_index=True)
-        sample_input[id_col] = [1] * num_rows + [2] * num_rows
+        sample_input[id_col] = [1] * num_rows_per_ts + [2] * num_rows_per_ts
 
         with mlflow.start_run() as run:
             mlflow_deepar_log_model(deepar_model, sample_input)
@@ -159,6 +159,7 @@ class TestDeepARModel(unittest.TestCase):
 
         # load the model and predict
         loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+
         pred_df = loaded_model.predict(sample_input)
 
         assert pred_df.columns.tolist() == [time_col, "yhat", id_col]

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -84,6 +84,7 @@ class TestDeepARModel(unittest.TestCase):
         deepar_model = DeepARModel(
             model=self.model,
             horizon=self.prediction_length,
+            frequency="d",
             num_samples=1,
             target_col=target_col,
             time_col=time_col,
@@ -127,6 +128,7 @@ class TestDeepARModel(unittest.TestCase):
             model=self.model,
             horizon=self.prediction_length,
             num_samples=1,
+            frequency="d",
             target_col=target_col,
             time_col=time_col,
             id_cols=[id_col],

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -115,9 +115,9 @@ class TestDeepARModel(unittest.TestCase):
         loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
         pred_df = loaded_model.predict(sample_input)
 
-        assert pred_df.columns.tolist() == [time_col, "yhat"]
-        assert len(pred_df) == self.prediction_length
-        assert pred_df[time_col].min() > sample_input[time_col].max()
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
+        self.assertEqual(len(pred_df), self.prediction_length)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
 
     def test_model_save_and_load_multi_series(self):
         target_col = "sales"
@@ -162,9 +162,53 @@ class TestDeepARModel(unittest.TestCase):
 
         pred_df = loaded_model.predict(sample_input)
 
-        assert pred_df.columns.tolist() == [time_col, "yhat", id_col]
-        assert len(pred_df) == self.prediction_length * 2
-        assert pred_df[time_col].min() > sample_input[time_col].max()
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat", id_col])
+        self.assertEqual(len(pred_df), self.prediction_length * 2)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
+
+    def test_model_save_and_load_multi_series_multi_id_cols(self):
+        target_col = "sales"
+        time_col = "date"
+        id_cols = ["store", "dept"]
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            num_samples=1,
+            frequency="d",
+            target_col=target_col,
+            time_col=time_col,
+            id_cols=id_cols,
+        )
+
+        num_rows_per_ts = 5
+        sample_input_base = pd.concat(
+            [
+                pd.to_datetime(
+                    pd.Series(range(num_rows_per_ts), name=time_col).apply(
+                        lambda i: f"2020-10-{3 * i + 1}"
+                    )
+                ),
+                pd.Series(range(num_rows_per_ts), name=target_col),
+            ],
+            axis=1,
+        )
+        sample_input = pd.concat([sample_input_base.copy(), sample_input_base.copy(),
+                                  sample_input_base.copy(), sample_input_base.copy(),], ignore_index=True)
+        sample_input[id_cols[0]] = ['A'] * (2 * num_rows_per_ts) + ['B'] * (2 * num_rows_per_ts)
+        sample_input[id_cols[1]] = (['X'] * num_rows_per_ts + ['Y'] * num_rows_per_ts) * 2
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+        run_id = run.info.run_id
+
+        # load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+        pred_df = loaded_model.predict(sample_input)
+
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat", "store-dept"])
+        self.assertEqual(len(pred_df), self.prediction_length * 4)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
 
     def _check_requirements(self, run_id: str):
         # read requirements.txt from the run

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2024 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+import pandas as pd
+
+from databricks.automl_runtime.forecast.deepar.utils import set_index_and_fill_missing_time_steps
+
+class TestDeepARUtils(unittest.TestCase):
+    def test_single_series_filled(self):
+        target_col = "sales"
+        time_col = "date"
+        num_rows = 10
+
+        base_df = pd.concat(
+            [
+                pd.to_datetime(
+                    pd.Series(range(num_rows), name=time_col).apply(
+                        lambda i: f"2020-10-{i + 1}"
+                    )
+                ),
+                pd.Series(range(num_rows), name=target_col),
+            ],
+            axis=1,
+        )
+        dropped_df = base_df.drop([4, 5]).reset_index(drop=True)
+
+        transformed_df = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D")
+
+        expected_df = base_df.copy()
+        expected_df.loc[[4, 5], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None).asfreq("D")
+
+        pd.testing.assert_frame_equal(transformed_df, expected_df)
+


### PR DESCRIPTION
Currently the `predict` function of DeepAR wouldn't work for datasets loaded from MLflow properly.

- Added `set_index_and_fill_missing_time_steps` utility function, this is used in `predict`, and we shall replace the entire data preprocessing logic before DeepAR training with this too.
- Support single series, multi series (single id_col / multiple id_cols) for `predict`
- Bump version for the next release

Tests
- [x] Pass existing unit tests
- [x] Add unit tests for missing time steps