### PR TITLE
Fix the frequency for DeepAR PandasDataset

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -124,7 +124,7 @@ class DeepARModel(ForecastModel):
                                                                         self._frequency,
                                                                         self._id_cols)
 
-        test_ds = PandasDataset(model_input_transformed, target=self._target_col)
+        test_ds = PandasDataset(model_input_transformed, target=self._target_col, freq=self._frequency)
 
         forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
         forecast_sample_list = list(forecast_iter)

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.3"  # pragma: no cover
+__version__ = "0.2.20.4.dev0"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.4.dev0"  # pragma: no cover
+__version__ = "0.2.20.4"  # pragma: no cover


### PR DESCRIPTION
## What is the PR fixing?
   AutoML couldn't register DeepAR models for some multi-series dataset, because the sample input may only contain 1 unique timestamp, where `PandasDataset` would fail to instantiate because of `infer_freq` failure.

  This PR explicitly specifies the frequency.


## How is it tested?
  Manual testing: use the AutoML runtime wheel in the AutoML library, and test a multi-series dataset in E2 dogfood
  - [Job run
](https://e2-dogfood.staging.cloud.databricks.com/jobs/1061270842941666/runs/1?o=6051921418418893)
  - [Experiment](https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/1644664309409946?viewStateShareKey=e73366865a97cf7c4371e9dbbdf911130e50ad3bd6b375991f9d9662505fa3d5)
  -  Each DeepAR model has a signature <img width="600" alt="image" src="https://github.com/user-attachments/assets/f744a66a-faab-4686-9a2d-20579383bac6">
 