### PR TITLE
Fix weekly date range bug for deepar

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -35,6 +35,13 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
              multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
     """
     total_min, total_max = df[time_col].min(), df[time_col].max()
+
+    # We need to adjust the frequency for pd.date_range if it is weekly,
+    # otherwise it would always be "W-SUN"
+    if frequency.upper() == "W":
+        weekday_name = total_min.strftime("%a").upper() # e.g., "FRI"
+        frequency = f"W-{weekday_name}"
+
     new_index_full = pd.date_range(total_min, total_max, freq=frequency)
 
     if id_cols is not None:

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.4"  # pragma: no cover
+__version__ = "0.2.20.5.dev0"  # pragma: no cover

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import unittest
+from idlelib.pyparse import trans
 
 import pandas as pd
 
@@ -108,3 +109,38 @@ class TestDeepARUtils(unittest.TestCase):
         expected_first_df = expected_first_df.set_index(time_col).rename_axis(None).asfreq("D")
 
         pd.testing.assert_frame_equal(transformed_df_dict["1-1"], expected_first_df)
+
+    def test_single_series_week_day_index(self):
+        target_col = "sales"
+        time_col = "date"
+        num_weeks = 10
+
+        # Starting from first Friday in 2020
+        base_dates = pd.date_range(
+            start='2020-01-03',  # First Friday of 2020
+            periods=num_weeks,
+            freq='W-FRI'  # Weekly frequency starting Friday
+        )
+
+        base_df = pd.DataFrame({
+            time_col: base_dates,
+            target_col: range(num_weeks)
+        })
+
+        # Create a dataframe with missing weeks (drop weeks 3 and 4)
+        dropped_df = base_df.drop([3, 4]).reset_index(drop=True)
+
+        # Transform the dataframe
+        transformed_df = set_index_and_fill_missing_time_steps(
+            dropped_df,
+            time_col,
+            "W" # Weekly frequency **without** specifying Friday
+        )
+
+        # Create expected dataframe
+        expected_df = base_df.copy()
+        expected_df.loc[[3, 4], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None).asfreq("W-FRI")
+
+        # Assert equality
+        pd.testing.assert_frame_equal(transformed_df, expected_df)

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import unittest
-from idlelib.pyparse import trans
 
 import pandas as pd
 


### PR DESCRIPTION
## What is changed?
Specify the "W-{weekday}" instead of "W" for the `pd.date_range` frequency, so that there is no mismatch between the new index and the original time column's dates.

- Previously: `new_index_full` can start from `2010-02-07` (a Sunday) despite `total_min` is `2010-02-05` (a Friday), because `pd.date_range` assumes that a weekly frequency starts from a Sunday (`W-SUN`)
- Now: the start of `new_index_full` is aligned with `total_min`

## How is it tested?
- [x] Added unit test: provide a dataframe where the dates are Fridays, and the frequency is "W". Before the fix, the unit test would fail with the target column of the output dataframe(s) being all `nan`.
- [x] Manual testing: tested with the Walmart Sales dataset, the DeepAR metrics used to be `NaN` before the change
<img width="999" alt="image" src="https://github.com/user-attachments/assets/32338e7b-a4d0-41a9-8b4b-6b07dfa1296e">
