### PR TITLE
Take average to aggregate duplicate time_col for DeepAR

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 from typing import List, Optional
 
 import gluonts
@@ -37,7 +36,6 @@ DEEPAR_CONDA_ENV = _mlflow_conda_env(
     additional_pip_deps=DEEPAR_ADDITIONAL_PIP_DEPS
 )
 
-_logger = logging.getLogger(__name__)
 
 class DeepARModel(ForecastModel):
     """
@@ -96,7 +94,6 @@ class DeepARModel(ForecastModel):
         model_input = model_input.groupby(group_cols).agg({self._target_col: "mean"}).reset_index()
 
         forecast_sample_list = self.predict_samples(model_input, num_samples=self._num_samples)
-
 
         pred_df = pd.concat(
             [

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -86,13 +86,6 @@ class DeepARModel(ForecastModel):
             required_cols += self._id_cols
         self._validate_cols(model_input, required_cols)
 
-        # Group by the time column in case there are multiple rows for each time column,
-        # for example, the user didn't provide all the identity columns for a multi-series dataset
-        group_cols = [self._time_col]
-        if self._id_cols:
-            group_cols += self._id_cols
-        model_input = model_input.groupby(group_cols).agg({self._target_col: "mean"}).reset_index()
-
         forecast_sample_list = self.predict_samples(model_input, num_samples=self._num_samples)
 
         pred_df = pd.concat(
@@ -125,6 +118,13 @@ class DeepARModel(ForecastModel):
         """
         if num_samples is None:
             num_samples = self._num_samples
+
+        # Group by the time column in case there are multiple rows for each time column,
+        # for example, the user didn't provide all the identity columns for a multi-series dataset
+        group_cols = [self._time_col]
+        if self._id_cols:
+            group_cols += self._id_cols
+        model_input = model_input.groupby(group_cols).agg({self._target_col: "mean"}).reset_index()
 
         model_input_transformed = set_index_and_fill_missing_time_steps(model_input,
                                                                         self._time_col,

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -89,7 +89,7 @@ class DeepARModel(ForecastModel):
         self._validate_cols(model_input, required_cols)
 
         # Group by the time column in case there are multiple rows for each time column,
-        # for example, the user didn't provide identity columns for a multi-series dataset
+        # for example, the user didn't provide all the identity columns for a multi-series dataset
         group_cols = [self._time_col]
         if self._id_cols:
             group_cols += self._id_cols

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import logging
 from typing import List, Optional
 
 import gluonts
@@ -36,6 +37,7 @@ DEEPAR_CONDA_ENV = _mlflow_conda_env(
     additional_pip_deps=DEEPAR_ADDITIONAL_PIP_DEPS
 )
 
+_logger = logging.getLogger(__name__)
 
 class DeepARModel(ForecastModel):
     """
@@ -86,7 +88,15 @@ class DeepARModel(ForecastModel):
             required_cols += self._id_cols
         self._validate_cols(model_input, required_cols)
 
+        # Group by the time column in case there are multiple rows for each time column,
+        # for example, the user didn't provide identity columns for a multi-series dataset
+        group_cols = [self._time_col]
+        if self._id_cols:
+            group_cols += self._id_cols
+        model_input = model_input.groupby(group_cols).agg({self._target_col: "mean"}).reset_index()
+
         forecast_sample_list = self.predict_samples(model_input, num_samples=self._num_samples)
+
 
         pred_df = pd.concat(
             [

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.5.dev1"  # pragma: no cover
+__version__ = "0.2.20.5"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.5.dev0"  # pragma: no cover
+__version__ = "0.2.20.5.dev1"  # pragma: no cover

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -261,14 +261,6 @@ class TestDeepARModel(unittest.TestCase):
         loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
         pred_df = loaded_model.predict(sample_input)
 
-        # Get the grouped input data to verify the averaging
-        grouped_input = sample_input.groupby(time_col)[target_col].mean()
-
-        # Verify that our input data was correctly averaged
-        self.assertEqual(grouped_input["2020-10-01"], 15.0)  # (10 + 20) / 2
-        self.assertEqual(grouped_input["2020-10-04"], 60.0)  # (30 + 60 + 90) / 3
-        self.assertEqual(grouped_input["2020-10-07"], 100.0)  # single value
-
         # Verify the prediction output format
         self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
         self.assertEqual(len(pred_df), self.prediction_length)

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -77,6 +77,15 @@ class TestDeepARModel(unittest.TestCase):
             device="cpu",
         )
 
+    def _check_requirements(self, run_id: str):
+        # read requirements.txt from the run
+        requirements_path = mlflow.artifacts.download_artifacts(f"runs:/{run_id}/model/requirements.txt")
+        with open(requirements_path, "r") as f:
+            requirements = f.read()
+        # check if all additional dependencies are logged
+        for dependency in DEEPAR_ADDITIONAL_PIP_DEPS:
+            self.assertIn(dependency, requirements, f"requirements.txt should contain {dependency} but got {requirements}")
+
     def test_model_save_and_load_single_series(self):
         target_col = "sales"
         time_col = "date"
@@ -210,11 +219,57 @@ class TestDeepARModel(unittest.TestCase):
         self.assertEqual(len(pred_df), self.prediction_length * 4)
         self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
 
-    def _check_requirements(self, run_id: str):
-        # read requirements.txt from the run
-        requirements_path = mlflow.artifacts.download_artifacts(f"runs:/{run_id}/model/requirements.txt")
-        with open(requirements_path, "r") as f:
-            requirements = f.read()
-        # check if all additional dependencies are logged
-        for dependency in DEEPAR_ADDITIONAL_PIP_DEPS:
-            self.assertIn(dependency, requirements, f"requirements.txt should contain {dependency} but got {requirements}")
+    def test_model_prediction_with_duplicate_timestamps(self):
+        """
+        Test that the model correctly handles and averages multiple rows with the same timestamp
+        when identity columns are not provided.
+        """
+        target_col = "sales"
+        time_col = "date"
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            frequency="d",
+            num_samples=1,
+            target_col=target_col,
+            time_col=time_col,
+        )
+
+        # Create sample input with duplicate timestamps
+        dates = pd.to_datetime([
+            "2020-10-01", "2020-10-01",  # duplicate date with different values
+            "2020-10-04", "2020-10-04", "2020-10-04",  # triple duplicate
+            "2020-10-07"  # single entry
+        ])
+
+        sales = [10, 20,  # should average to 15
+                 30, 60, 90,  # should average to 60
+                 100]  # single value stays 100
+
+        sample_input = pd.DataFrame({
+            time_col: dates,
+            target_col: sales
+        })
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+
+        run_id = run.info.run_id
+
+        # Load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+        pred_df = loaded_model.predict(sample_input)
+
+        # Get the grouped input data to verify the averaging
+        grouped_input = sample_input.groupby(time_col)[target_col].mean()
+
+        # Verify that our input data was correctly averaged
+        self.assertEqual(grouped_input["2020-10-01"], 15.0)  # (10 + 20) / 2
+        self.assertEqual(grouped_input["2020-10-04"], 60.0)  # (30 + 60 + 90) / 3
+        self.assertEqual(grouped_input["2020-10-07"], 100.0)  # single value
+
+        # Verify the prediction output format
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
+        self.assertEqual(len(pred_df), self.prediction_length)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())


### PR DESCRIPTION
## What is changed?
Before the change, calling `loaded_model.predict(df)` for a `DeepARModel` would fail if `df` has multiple rows that have the same `time_col` and `id_cols`:

```py
ValueError: cannot reindex on an axis with duplicate labels
```

We add this preprocessing logic inside `predict()` so that users can directly call this function without additional preprocessing to aggregate the dataframe.

## How is it tested?
- [x] Added unit test: without the `groupby` line, this new test will fail with the exact same `ValueError`
- [x] Existing tests work the same
- [x] Manual testing: by changing the `databricks-automl-runtime` version to my uploaded wheel, DeepAR tuning trial notebook completes without errors for `forecasting_tv_sales_small_dataset` without specifying identity columns [job run link](https://e2-dogfood.staging.cloud.databricks.com/jobs/1118598333581389/runs/1?o=6051921418418893), [notebook](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/3830593516199824?o=6051921418418893)