### PR TITLE
[ML-49316] Fix the bug "AttributeError: 'pandas._libs.tslibs.offsets.YearBegin' object has no attribute '_period_dtype_code'"

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -131,7 +131,7 @@ class DeepARModel(ForecastModel):
                                                                         self._frequency,
                                                                         self._id_cols)
 
-        test_ds = PandasDataset(model_input_transformed, target=self._target_col, freq=self._frequency)
+        test_ds = PandasDataset(model_input_transformed, target=self._target_col)
 
         forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
         forecast_sample_list = list(forecast_iter)

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -265,3 +265,44 @@ class TestDeepARModel(unittest.TestCase):
         self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
         self.assertEqual(len(pred_df), self.prediction_length)
         self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
+
+    def test_model_prediction_with_monthly_data(self):
+        target_col = "sales"
+        time_col = "date"
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            frequency="MS",
+            num_samples=1,
+            target_col=target_col,
+            time_col=time_col,
+        )
+
+        # Create sample input with duplicate timestamps
+        dates = pd.to_datetime([
+            "2020-10-01", "2020-11-01", "2020-12-01",
+            "2021-01-01", "2021-02-01", "2021-03-01"
+        ])
+
+        sales = [10, 20, 30, 
+                 60, 90, 100]
+
+        sample_input = pd.DataFrame({
+            time_col: dates,
+            target_col: sales
+        })
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+
+        run_id = run.info.run_id
+
+        # Load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+        pred_df = loaded_model.predict(sample_input)
+
+        # Verify the prediction output format
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
+        self.assertEqual(len(pred_df), self.prediction_length)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())


### PR DESCRIPTION
# PR description
This PR removes the input argument, `freq`, when calling `PandasDataset` in `predict_sample` function
There are two reasons.
1. It causes a bug when frequency is monthly, quarterly and yearly. In short, when users specify those frequencies,  'MS', 'QS' or 'YS' will be passed to `DeepARModel`, see the trial [notebook](https://src.dev.databricks.com/databricks-eng/universe@cc8acdfa32efc247fc30e60730105fae15021288/-/blob/automl/python/databricks/automl/core/sections/templates/forecast/base_deepar.jinja?L9-10), thus [PandasDataset](https://src.dev.databricks.com/databricks/automl@branch-0.2.20.5/-/blob/runtime/databricks/automl_runtime/forecast/deepar/model.py?L134) will take those 'MS', 'QS' and 'YS'. Inside `PandasDataset`, [`df.to_period(freq)`](https://github.com/awslabs/gluonts/blob/dev/src/gluonts/dataset/pandas.py#L174) is called, resulting the AttributeError.
2. It is different from what is done during training, resulting in training-prediction skew. During training, we do not specify `freq` when calling `PandasDataset`, see [link](https://src.dev.databricks.com/databricks-eng/universe@b999b50216be2d51bda50fbac776ad38fdaf7b45/-/blob/automl/python/databricks/automl/core/sections/templates/forecast/base_deepar.jinja?L42-44)

See jira [ticket](https://databricks.atlassian.net/jira/software/c/projects/ML/boards/3737?selectedIssue=ML-49316) for bug details.

# How I tested?
1. I added a unit test in model_test.py. To run the test, make sure you have a virtual env and install all libraries in environment.txt and test-environment.txt
```
PYTHONPATH=/Users/lan.zhang/automl/runtime/ pytest tests/automl_runtime/forecast/deepar/model_test.py
```
2. I did e2e test. notebook [link](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/3625753296542474?o=6051921418418893#command/3625753296542475)
  - I spin up a compute with MLR 14.3
  - Install the automl_runtime library in the compute
  - comment out this [line](https://src.dev.databricks.com/databricks-eng/universe@cc8acdfa32efc247fc30e60730105fae15021288/-/blob/automl/python/databricks/automl/core/sections/templates/pip_install_deepar.jinja?L1) to use the updated automl_runtime
  - install the automl library in the first cell of the test notebook
  - run the notebook
