### PR TITLE
[ML-52565] Move Preprocessing Pipelines into ProphetModel and MultiSeriesProphetModel

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -70,8 +70,8 @@ class ProphetModel(ForecastModel):
         self._frequency_quantity = frequency_quantity
         self._time_col = time_col
         self._is_quaterly = is_quaterly_alias(frequency_unit)
-        self._preprocess_func = preprocess_func
         self._split_col = split_col
+        self._preprocess_func = preprocess_func
         super().__init__()
 
     def load_context(self, context: mlflow.pyfunc.model.PythonModelContext) -> None:
@@ -142,8 +142,12 @@ class ProphetModel(ForecastModel):
         self._validate_cols(model_input, [self._time_col])
         test_df = model_input.copy()
 
-        # apply the same preprocessing pipeline to test_df, which requires "y" and split column, remove them after preprocessed
         if self._preprocess_func and self._split_col:
+        # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+        # and the split column to be present, as they are used in the trial notebook. These columns are added 
+        # temporarily and removed after preprocessing.
+        # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+        # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
             test_df["y"] = None
             test_df[self._split_col] = "prediction"
             test_df = self._preprocess_func(test_df)
@@ -323,8 +327,12 @@ class MultiSeriesProphetModel(ProphetModel):
         test_df = model_input.copy()
         test_df["ts_id"] = test_df[self._id_cols].apply(tuple, axis=1)
 
-        # apply the same preprocessing pipeline to test_df, which requires "y" and split column, remove them after preprocessed
         if self._preprocess_func and self._split_col:
+        # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+        # and the split column to be present, as they are used in the trial notebook. These columns are added 
+        # temporarily and removed after preprocessing.
+        # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+        # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
             test_df["y"] = None
             test_df[self._split_col] = "prediction"
             test_df = test_df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -146,7 +146,7 @@ class ProphetModel(ForecastModel):
         if self._preprocess_func and self._split_col:
             test_df["y"] = None
             test_df[self._split_col] = "prediction"
-            test_df = test_df.apply(self._preprocess_func).reset_index(drop=True)
+            test_df = self._preprocess_func(test_df)
             test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
 
         test_df.rename(columns={self._time_col: "ds"}, inplace=True)

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -143,11 +143,11 @@ class ProphetModel(ForecastModel):
         test_df = model_input.copy()
 
         if self._preprocess_func and self._split_col:
-        # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
-        # and the split column to be present, as they are used in the trial notebook. These columns are added 
-        # temporarily and removed after preprocessing.
-        # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
-        # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
             test_df["y"] = None
             test_df[self._split_col] = "prediction"
             test_df = self._preprocess_func(test_df)
@@ -328,11 +328,11 @@ class MultiSeriesProphetModel(ProphetModel):
         test_df["ts_id"] = test_df[self._id_cols].apply(tuple, axis=1)
 
         if self._preprocess_func and self._split_col:
-        # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
-        # and the split column to be present, as they are used in the trial notebook. These columns are added 
-        # temporarily and removed after preprocessing.
-        # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
-        # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
             test_df["y"] = None
             test_df[self._split_col] = ""
             test_df = test_df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -334,7 +334,7 @@ class MultiSeriesProphetModel(ProphetModel):
         # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
         # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
             test_df["y"] = None
-            test_df[self._split_col] = "prediction"
+            test_df[self._split_col] = ""
             test_df = test_df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)
             test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
 

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -50,7 +50,9 @@ class ProphetModel(ForecastModel):
                  horizon: int, 
                  frequency_unit: str, 
                  frequency_quantity: int,
-                 time_col: str) -> None:
+                 time_col: str,
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for mlflow
         :param model_json: json string of the Prophet model or
@@ -59,6 +61,8 @@ class ProphetModel(ForecastModel):
         :param frequency_unit: the frequency unit of the time series
         :param frequency_quantity: the frequency quantity of the time series
         :param time_col: the column name of the time column
+        :param split_col: Optional column name of the split columns
+        :param preprocess_func: Optional callable function for preprocessing input data
         """
         self._model_json = model_json
         self._horizon = horizon
@@ -66,6 +70,8 @@ class ProphetModel(ForecastModel):
         self._frequency_quantity = frequency_quantity
         self._time_col = time_col
         self._is_quaterly = is_quaterly_alias(frequency_unit)
+        self._preprocess_func = preprocess_func
+        self._split_col = split_col
         super().__init__()
 
     def load_context(self, context: mlflow.pyfunc.model.PythonModelContext) -> None:
@@ -134,7 +140,16 @@ class ProphetModel(ForecastModel):
         :return: A pd.DataFrame with the forecast components.
         """
         self._validate_cols(model_input, [self._time_col])
-        test_df = pd.DataFrame({"ds": model_input[self._time_col]})
+        test_df = model_input.copy()
+
+        # apply the same preprocessing pipeline to test_df, which requires "y" and split column, remove them after preprocessed
+        if self._preprocess_func and self._split_col:
+            test_df["y"] = None
+            test_df[self._split_col] = "prediction"
+            test_df = test_df.apply(self._preprocess_func).reset_index(drop=True)
+            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+
+        test_df.rename(columns={self._time_col: "ds"}, inplace=True)
         predict_df = self.model().predict(test_df)
         return predict_df["yhat"]
 
@@ -150,9 +165,17 @@ class MultiSeriesProphetModel(ProphetModel):
     Prophet mlflow model wrapper for multi-series forecasting.
     """
 
-    def __init__(self, model_json: Dict[Tuple, str], timeseries_starts: Dict[Tuple, pd.Timestamp],
-                 timeseries_end: str, horizon: int, frequency_unit: str, frequency_quantity: int, time_col: str, id_cols: List[str],
-                 ) -> None:
+    def __init__(self, 
+                 model_json: Dict[Tuple, str], 
+                 timeseries_starts: Dict[Tuple, pd.Timestamp],
+                 timeseries_end: str, 
+                 horizon: int, 
+                 frequency_unit: str, 
+                 frequency_quantity: int, 
+                 time_col: str, 
+                 id_cols: List[str],
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for mlflow
         :param model_json: the dictionary of json strings of Prophet model for multi-series forecasting
@@ -163,8 +186,10 @@ class MultiSeriesProphetModel(ProphetModel):
         :param frequency_quantity: the frequency quantity of the time series
         :param time_col: the column name of the time column
         :param id_cols: the column names of the identity columns for multi-series time series
+        :param split_col: Optional column name of the split columns
+        :param preprocess_func: Optional callable function for preprocessing input data
         """
-        super().__init__(model_json, horizon, frequency_unit, frequency_quantity, time_col)
+        super().__init__(model_json, horizon, frequency_unit, frequency_quantity, time_col, split_col, preprocess_func)
         self._frequency_unit = frequency_unit
         self._frequency_quantity = frequency_quantity
         self._timeseries_end = timeseries_end
@@ -297,6 +322,14 @@ class MultiSeriesProphetModel(ProphetModel):
         self._validate_cols(model_input, self._id_cols + [self._time_col])
         test_df = model_input.copy()
         test_df["ts_id"] = test_df[self._id_cols].apply(tuple, axis=1)
+
+        # apply the same preprocessing pipeline to test_df, which requires "y" and split column, remove them after preprocessed
+        if self._preprocess_func and self._split_col:
+            test_df["y"] = None
+            test_df[self._split_col] = "prediction"
+            test_df = test_df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)
+            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+
         test_df.rename(columns={self._time_col: "ds"}, inplace=True)
 
         def model_prediction(df):

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -80,7 +80,7 @@ class TestProphetModel(BaseProphetModelTest):
         cls.model = model_from_json(cls.model_json)
 
     def test_model_save_and_load(self):
-        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds")
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds", )
 
         with mlflow.start_run() as run:
             mlflow_prophet_log_model(prophet_model)
@@ -178,6 +178,23 @@ class TestProphetModel(BaseProphetModelTest):
         with pytest.raises(MlflowException, match="Model is missing inputs") as e:
             prophet_model.predict(test_df)
         assert e.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+    def test_predict_with_preprocess_func(self):
+        def preprocess_func(df):
+            return df
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds", "split", preprocess_func)
+        test_df = pd.DataFrame(
+            {
+                "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-04")], 
+                "split": ["train", "train"]
+            }
+        )
+        expected_test_df = test_df.copy()
+        yhat = prophet_model.predict(None, test_df)
+        self.assertEqual(2, len(yhat))
+        pd.testing.assert_frame_equal(
+            test_df, expected_test_df
+        )
 
 
 class TestMultiSeriesProphetModel(BaseProphetModelTest):
@@ -405,3 +422,21 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
     def test_make_future_dataframe_invalid_group(self):
         with pytest.raises(ValueError, match="Invalid groups:"):
             future_df = self.prophet_model.make_future_dataframe(groups=[(1,)])
+
+
+    def test_predict_with_preprocess_func(self):
+        def preprocess_func(df):
+            return df
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds", "split", preprocess_func)
+        test_df = pd.DataFrame(
+            {
+                "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-04")], 
+                "split": ["train", "train"]
+            }
+        )
+        expected_test_df = test_df.copy()
+        yhat = prophet_model.predict(None, test_df)
+        self.assertEqual(2, len(yhat))
+        pd.testing.assert_frame_equal(
+            test_df, expected_test_df
+        )

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -187,7 +187,7 @@ class TestProphetModel(BaseProphetModelTest):
         test_df = pd.DataFrame(
             {
                 "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-04")], 
-                "split": ["train", "train"],
+                "split": ["train", "test"],
                 "y": [1, 2]
             }
         )
@@ -445,7 +445,7 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
         test_df = pd.DataFrame(
             {
                 "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-02")], 
-                "split": ["train", "train"],
+                "split": ["train", "test"],
                 "id": ["1", "2"],
             }
         )

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -181,20 +181,18 @@ class TestProphetModel(BaseProphetModelTest):
 
     def test_predict_with_preprocess_func(self):
         def preprocess_func(df):
+            df["y"] = df["y"] * 2
             return df
         prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds", "split", preprocess_func)
         test_df = pd.DataFrame(
             {
                 "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-04")], 
-                "split": ["train", "train"]
+                "split": ["train", "train"],
+                "y": [1, 2]
             }
         )
-        expected_test_df = test_df.copy()
         yhat = prophet_model.predict(None, test_df)
         self.assertEqual(2, len(yhat))
-        pd.testing.assert_frame_equal(
-            test_df, expected_test_df
-        )
 
 
 class TestMultiSeriesProphetModel(BaseProphetModelTest):
@@ -426,17 +424,30 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
 
     def test_predict_with_preprocess_func(self):
         def preprocess_func(df):
+            df["y"] = df["y"] + 1
             return df
-        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds", "split", preprocess_func)
+        multi_series_model_json = {("1", ): self.model_json, ("2", ): self.model_json}
+        multi_series_start = {
+            (1, "1"): pd.Timestamp("2020-07-01"),
+            (2, "1"): pd.Timestamp("2020-07-01"),
+        }
+        prophet_model = MultiSeriesProphetModel(
+            multi_series_model_json,
+            multi_series_start, 
+            "2020-07-25",
+            1, 
+            "days", 
+            1, 
+            "ds", 
+            ["id"],
+            "split", 
+            preprocess_func)
         test_df = pd.DataFrame(
             {
-                "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-04")], 
-                "split": ["train", "train"]
+                "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-02")], 
+                "split": ["train", "train"],
+                "id": ["1", "2"],
             }
         )
-        expected_test_df = test_df.copy()
         yhat = prophet_model.predict(None, test_df)
         self.assertEqual(2, len(yhat))
-        pd.testing.assert_frame_equal(
-            test_df, expected_test_df
-        )


### PR DESCRIPTION
# Description
This PR is the automl runtime change for moving preprocessing pipelines into model class to avoid training and inference gap. 

Background is that in trial notebook (training), there are some preprocessing pipelines for feature columns (boolean, numerical and string columns). These operations on those columns are not recorded in the model object so they are missing during inference stage, resulting in a wrong behavior. 

So this PR adds two arguments to ProphetModel and MultiSeriesProphetModel, split_col and preprocess_func. split_col is required by some preprocessing pipeline, preprocess_func is the same function used during training.

# Testing 
Unit tests: added two unit test cases to verify predict function works with preprocess_func
Manual tests: Tested together with https://github.com/databricks-eng/universe/pull/1028060
1. generate automl runtime wheel and core lib wheel by 
```
python3 setup.py sdist bdist_wheel
```
2. upload the wheel to e2 dogfood and run the test notebook, [single series with covariates](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/1446503195066913?o=6051921418418893#command/1446503195066924), [multi series with covariates](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/1446503195066875?o=6051921418418893#command/1446503195066879), [single series without covariates](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/1446503195087298?o=6051921418418893#command/1446503195087309), [multi series without covariates](https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/1446503195087362?o=6051921418418893#command/1446503195087373)
3. verify that all trial notebooks run successfully and model registered in mlflow experiment
<img width="773" alt="image" src="https://github.com/user-attachments/assets/8444359c-eae0-4fc2-89c6-cbb940d93302" />
