### PR TITLE
[ML-52570] Add covariate inference support in automl runtime for ARIMA

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -150,13 +150,13 @@ class ArimaModel(AbstractArimaModel):
         if self._preprocess_func and self._split_col:
             future_df = apply_preprocess_func(future_df, self._preprocess_func, self._split_col)
         horizon = horizon or self._horizon
-        X = None
+        future_feature_df = None
         if self._exogenous_cols and future_df is not None:
             time_col = self._time_col if self._time_col in future_df.columns else "ds"
-            X = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
-        future_pd = self._forecast(horizon, X)
+            future_feature_df = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
+        future_pd = self._forecast(horizon, future_feature_df)
         if include_history:
-            in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, X=X)
+            in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, feature_df=future_feature_df)
             return pd.concat([in_sample_pd, future_pd]).reset_index(drop=True)
         else:
             return future_pd
@@ -226,18 +226,18 @@ class ArimaModel(AbstractArimaModel):
         # Out-of-sample prediction if needed
         horizon = calculate_period_differences(self._end_ds, max(df["ds"]), self._frequency_unit, self._frequency_quantity)
         if horizon > 0:
-            X_future = df[df["ds"] > self._end_ds].set_index("ds")
+            future_feature_df = df[df["ds"] > self._end_ds].set_index("ds")
             future_pd = self._forecast(
                 horizon,
-                X=X_future[self._exogenous_cols] if self._exogenous_cols else None)
+                feature_df=future_feature_df[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(future_pd)
         # In-sample prediction if needed
         if pred_start_ds <= self._end_ds:
-            X_in_sample = df[df["ds"] <= self._end_ds].set_index("ds")
+            df_in_sample = df[df["ds"] <= self._end_ds].set_index("ds")
             in_sample_pd = self._predict_in_sample(
                 start_ds=pred_start_ds,
                 end_ds=self._end_ds,
-                X=X_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
+                feature_df=df_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(in_sample_pd)
         # Map predictions back to given timestamps
         preds_pd = pd.concat(preds_pds).set_index("ds")
@@ -248,7 +248,7 @@ class ArimaModel(AbstractArimaModel):
         self,
         start_ds: pd.Timestamp = None,
         end_ds: pd.Timestamp = None,
-        X: pd.DataFrame = None) -> pd.DataFrame:
+        feature_df: pd.DataFrame = None) -> pd.DataFrame:
         if start_ds and end_ds:
             start_idx = calculate_period_differences(self._start_ds, start_ds, self._frequency_unit, self._frequency_quantity)
             end_idx = calculate_period_differences(self._start_ds, end_ds, self._frequency_unit, self._frequency_quantity)
@@ -259,7 +259,7 @@ class ArimaModel(AbstractArimaModel):
         d = self.model().order[1]
         start_idx = max(start_idx, d)
         preds_in_sample, conf_in_sample = self.model().predict_in_sample(
-            X=X,
+            X=feature_df,
             start=start_idx,
             end=end_idx,
             return_conf_int=True)
@@ -272,12 +272,12 @@ class ArimaModel(AbstractArimaModel):
     def _forecast(
         self,
         horizon: int = None,
-        X: pd.DataFrame = None) -> pd.DataFrame:
+        feature_df: pd.DataFrame = None) -> pd.DataFrame:
         # set horizon to the length of future_df if future_df is provided to avoid the length mismatch error from pmdarima
-        horizon = horizon or self._horizon if X is None else len(X)
+        horizon = horizon or self._horizon if feature_df is None else len(feature_df)
         preds, conf = self.model().predict(
             horizon,
-            X=X,
+            X=feature_df,
             return_conf_int=True)
         ds_indices = self._get_ds_indices(start_ds=self._end_ds, periods=horizon + 1, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[1:]
         preds_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds})

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -273,6 +273,7 @@ class ArimaModel(AbstractArimaModel):
         self,
         horizon: int = None,
         feature_df: pd.DataFrame = None) -> pd.DataFrame:
+        # Unlike Prophet, pmdarima does not require time column in the feature_df, it depends on horizon to determine the length of the prediction
         # set horizon to the length of future_df if future_df is provided to avoid the length mismatch error from pmdarima
         horizon = horizon or self._horizon if feature_df is None else len(feature_df)
         preds, conf = self.model().predict(

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -90,9 +90,17 @@ class ArimaModel(AbstractArimaModel):
     ARIMA mlflow model wrapper for univariate forecasting.
     """
 
-    def __init__(self, pickled_model: bytes, horizon: int, frequency_unit: str,
-                 frequency_quantity: int, start_ds: pd.Timestamp, end_ds: pd.Timestamp,
-                 time_col: str, exogenous_cols: Optional[List[str]] = None) -> None:
+    def __init__(self, 
+                 pickled_model: bytes, 
+                 horizon: int, 
+                 frequency_unit: str,
+                 frequency_quantity: int, 
+                 start_ds: pd.Timestamp, 
+                 end_ds: pd.Timestamp,
+                 time_col: str, 
+                 exogenous_cols: Optional[List[str]] = None,
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for ARIMA.
         :param pickled_model: the pickled ARIMA model as a bytes object.
@@ -114,6 +122,8 @@ class ArimaModel(AbstractArimaModel):
         self._end_ds = pd.to_datetime(end_ds)
         self._time_col = time_col
         self._exogenous_cols = exogenous_cols
+        self._split_col = split_col
+        self._preprocess_func = preprocess_func
 
     def model(self) -> pmdarima.arima.ARIMA:
         """
@@ -178,8 +188,44 @@ class ArimaModel(AbstractArimaModel):
         :return: A pd.Series with the prediction values.
         """
         self._validate_cols(model_input, [self._time_col])
-        result_df = self._predict_impl(model_input)
+        test_df = model_input.copy()
+        if self._preprocess_func and self._split_col:
+             # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            test_df["y"] = None
+            test_df[self._split_col] = "prediction"
+            test_df = self._preprocess_func(test_df)
+            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+        result_df = self._predict_impl(test_df)
         return result_df["yhat"]
+
+    def predict_with_full_df_returned(self, model_input: pd.DataFrame) -> pd.DataFrame:
+        """
+        Predict API for prediction tables with covariates.
+
+        Returns the prediction values for given timestamps in the input dataframe. If an input timestamp
+        to predict does not match the original frequency that the model trained on, an exception will be thrown.
+        :param model_input: The input dataframe of the model. Should have the same time column name
+                            as the training data of the ARIMA model.
+        :return: A pd.DataFrame with the prediction values.
+        """
+        self._validate_cols(model_input, [self._time_col])
+        test_df = model_input.copy()
+        if self._preprocess_func and self._split_col:
+             # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            test_df["y"] = None
+            test_df[self._split_col] = "prediction"
+            test_df = self._preprocess_func(test_df)
+            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+        result_df = self._predict_impl(test_df)
+        return result_df
 
     def _predict_impl(self, input_df: pd.DataFrame) -> pd.DataFrame:
         df = input_df.rename(columns={self._time_col: "ds"})
@@ -272,9 +318,18 @@ class MultiSeriesArimaModel(AbstractArimaModel):
     ARIMA mlflow model wrapper for multivariate forecasting.
     """
 
-    def __init__(self, pickled_model_dict: Dict[Tuple, bytes], horizon: int, frequency_unit: str, frequency_quantity: int,
-                 start_ds_dict: Dict[Tuple, pd.Timestamp], end_ds_dict: Dict[Tuple, pd.Timestamp],
-                 time_col: str, id_cols: List[str], exogenous_cols: Optional[List[str]] = None) -> None:
+    def __init__(self, 
+                 pickled_model_dict: Dict[Tuple, bytes], 
+                 horizon: int, 
+                 frequency_unit: str, 
+                 frequency_quantity: int,
+                 start_ds_dict: Dict[Tuple, pd.Timestamp], 
+                 end_ds_dict: Dict[Tuple, pd.Timestamp],
+                 time_col: str, 
+                 id_cols: List[str], 
+                 exogenous_cols: Optional[List[str]] = None,
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for multiseries ARIMA.
         :param pickled_model_dict: the dictionary of binarized ARIMA models for different time series.
@@ -298,6 +353,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         self._time_col = time_col
         self._id_cols = id_cols
         self._exogenous_cols = exogenous_cols
+        self._split_col = split_col
+        self._preprocess_func = preprocess_func
 
     def model(self, id_: Tuple) -> pmdarima.arima.ARIMA:
         """
@@ -400,9 +457,57 @@ class MultiSeriesArimaModel(AbstractArimaModel):
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if self._preprocess_func and self._split_col:
+            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            df["y"] = None
+            df[self._split_col] = ""
+            df = df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)
+            df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
         preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
         df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
         return df["yhat"]
+    
+    def predict_with_full_df_returned(self, model_input: pd.DataFrame) -> pd.DataFrame:
+        """
+        Predict API for prediction tables with covariates.
+
+        Returns the prediction values for given timestamps in the input dataframe. If an input timestamp
+        to predict does not match the original frequency that the model trained on, an exception will be thrown.
+        :param model_input: input dataframe of the model. Should have the same time column
+                            and identity columns names as the training data of the ARIMA model.
+        :return: A pd.DataFrame with the prediction values.
+        """
+        self._validate_cols(model_input, self._id_cols + [self._time_col])
+        df = model_input.copy()
+        df["ts_id"] = df[self._id_cols].apply(tuple, axis=1)
+        known_ids = set(self._pickled_models.keys())
+        ids = set(df["ts_id"].unique())
+        if not ids.issubset(known_ids):
+            raise MlflowException(
+                message=(
+                    f"Input data includes unseen values in id columns '{self._id_cols}'."
+                    f"Expected combined ids: {known_ids}\n"
+                    f"Got ids: {ids}\n"
+                ),
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        if self._preprocess_func and self._split_col:
+            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            df["y"] = None
+            df[self._split_col] = ""
+            df = df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)
+            df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+        preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
+        df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
+        return df
 
     def _predict_single_id(self, df: pd.DataFrame) -> pd.DataFrame:
         id_ = df["ts_id"].to_list()[0]
@@ -413,7 +518,9 @@ class MultiSeriesArimaModel(AbstractArimaModel):
                                            self._starts[id_],
                                            self._ends[id_],
                                            self._time_col,
-                                           self._exogenous_cols)
+                                           self._exogenous_cols,
+                                           self._split_col,
+                                           self._preprocess_func)
         df["yhat"] = arima_model_single_id.predict(context=None, model_input=df).to_list()
         return df
 

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -27,7 +27,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from databricks.automl_runtime.forecast import OFFSET_ALIAS_MAP, DATE_OFFSET_KEYWORD_MAP
 from databricks.automl_runtime.forecast.model import ForecastModel, mlflow_forecast_log_model
 from databricks.automl_runtime.forecast.utils import calculate_period_differences, is_frequency_consistency, \
-    make_future_dataframe, make_single_future_dataframe
+    make_future_dataframe, make_single_future_dataframe, apply_preprocess_func
 from databricks.automl_runtime import version
 
 
@@ -136,20 +136,22 @@ class ArimaModel(AbstractArimaModel):
         self,
         horizon: int = None,
         include_history: bool = True,
-        df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+        future_df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """
         Predict target column for given horizon_timedelta and history data.
         :param horizon: int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
-        :param df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
+        :param future_df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
         :return: A pd.DataFrame with the forecasts and confidence intervals for given horizon_timedelta and history data.
         """
+        if self._preprocess_func and self._split_col:
+            future_df = apply_preprocess_func(future_df, self._preprocess_func, self._split_col)
         horizon = horizon or self._horizon
         X = None
-        if self._exogenous_cols and df is not None:
+        if self._exogenous_cols and future_df is not None:
             time_col = self._time_col if self._time_col in df.columns else "ds"
-            X = (df[df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
+            X = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
         future_pd = self._forecast(horizon, X)
         if include_history:
             in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, X=X)
@@ -190,42 +192,9 @@ class ArimaModel(AbstractArimaModel):
         self._validate_cols(model_input, [self._time_col])
         test_df = model_input.copy()
         if self._preprocess_func and self._split_col:
-             # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
-            # and the split column to be present, as they are used in the trial notebook. These columns are added 
-            # temporarily and removed after preprocessing.
-            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
-            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
-            test_df["y"] = None
-            test_df[self._split_col] = "prediction"
-            test_df = self._preprocess_func(test_df)
-            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+            test_df = apply_preprocess_func(test_df, self._preprocess_func, self._split_col)
         result_df = self._predict_impl(test_df)
         return result_df["yhat"]
-
-    def predict_with_full_df_returned(self, model_input: pd.DataFrame) -> pd.DataFrame:
-        """
-        Predict API for prediction tables with covariates.
-
-        Returns the prediction values for given timestamps in the input dataframe. If an input timestamp
-        to predict does not match the original frequency that the model trained on, an exception will be thrown.
-        :param model_input: The input dataframe of the model. Should have the same time column name
-                            as the training data of the ARIMA model.
-        :return: A pd.DataFrame with the prediction values.
-        """
-        self._validate_cols(model_input, [self._time_col])
-        test_df = model_input.copy()
-        if self._preprocess_func and self._split_col:
-             # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
-            # and the split column to be present, as they are used in the trial notebook. These columns are added 
-            # temporarily and removed after preprocessing.
-            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
-            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
-            test_df["y"] = None
-            test_df[self._split_col] = "prediction"
-            test_df = self._preprocess_func(test_df)
-            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
-        result_df = self._predict_impl(test_df)
-        return result_df
 
     def _predict_impl(self, input_df: pd.DataFrame) -> pd.DataFrame:
         df = input_df.rename(columns={self._time_col: "ds"})
@@ -404,7 +373,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         self,
         horizon: int = None,
         include_history: bool = True,
-        df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+        future_df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """
         Predict target column for given horizon_timedelta and history data.
         :param horizon: Int number of periods to forecast forward.
@@ -415,7 +384,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         """
         horizon = horizon or self._horizon
         ids = self._pickled_models.keys()
-        preds_dfs = list(map(lambda id_: self._predict_timeseries_single_id(id_, horizon, include_history, df), ids))
+        preds_dfs = list(map(lambda id_: self._predict_timeseries_single_id(id_, horizon, include_history, future_df), ids))
         return pd.concat(preds_dfs).reset_index(drop=True)
 
     def _predict_timeseries_single_id(
@@ -458,15 +427,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
                 error_code=INVALID_PARAMETER_VALUE,
             )
         if self._preprocess_func and self._split_col:
-            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
-            # and the split column to be present, as they are used in the trial notebook. These columns are added 
-            # temporarily and removed after preprocessing.
-            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
-            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
-            df["y"] = None
-            df[self._split_col] = ""
-            df = df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)
-            df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+            df = apply_preprocess_func(df, self._preprocess_func, self._split_col)
         preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
         df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
         return df["yhat"]

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -150,7 +150,7 @@ class ArimaModel(AbstractArimaModel):
         horizon = horizon or self._horizon
         X = None
         if self._exogenous_cols and future_df is not None:
-            time_col = self._time_col if self._time_col in df.columns else "ds"
+            time_col = self._time_col if self._time_col in future_df.columns else "ds"
             X = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
         future_pd = self._forecast(horizon, X)
         if include_history:
@@ -271,7 +271,8 @@ class ArimaModel(AbstractArimaModel):
         self,
         horizon: int = None,
         X: pd.DataFrame = None) -> pd.DataFrame:
-        horizon = horizon or self._horizon
+        # set horizon to the length of future_df if future_df is provided to avoid the length mismatch error from pmdarima
+        horizon = horizon or self._horizon if X is None else len(X)
         preds, conf = self.model().predict(
             horizon,
             X=X,
@@ -379,11 +380,14 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         :param horizon: Int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
-        :param df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
+        :param future_df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
         :return: A pd.DataFrame with the forecast components.
         """
         horizon = horizon or self._horizon
         ids = self._pickled_models.keys()
+        if future_df is not None:
+            # Add ts_id column to future_df because preprocess_func requires it
+            future_df["ts_id"] = future_df[self._id_cols].apply(tuple, axis=1)
         preds_dfs = list(map(lambda id_: self._predict_timeseries_single_id(id_, horizon, include_history, future_df), ids))
         return pd.concat(preds_dfs).reset_index(drop=True)
 
@@ -394,7 +398,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         include_history: bool = True,
         df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         arima_model_single_id = ArimaModel(self._pickled_models[id_], self._horizon, self._frequency_unit, self._frequency_quantity,
-                                           self._starts[id_], self._ends[id_], self._time_col, self._exogenous_cols)
+                                           self._starts[id_], self._ends[id_], self._time_col, self._exogenous_cols, self._split_col, self._preprocess_func)
         preds_df = arima_model_single_id.predict_timeseries(horizon, include_history, df)
         for id, col_name in zip(id_, self._id_cols):
             preds_df[col_name] = id
@@ -431,44 +435,6 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
         df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
         return df["yhat"]
-    
-    def predict_with_full_df_returned(self, model_input: pd.DataFrame) -> pd.DataFrame:
-        """
-        Predict API for prediction tables with covariates.
-
-        Returns the prediction values for given timestamps in the input dataframe. If an input timestamp
-        to predict does not match the original frequency that the model trained on, an exception will be thrown.
-        :param model_input: input dataframe of the model. Should have the same time column
-                            and identity columns names as the training data of the ARIMA model.
-        :return: A pd.DataFrame with the prediction values.
-        """
-        self._validate_cols(model_input, self._id_cols + [self._time_col])
-        df = model_input.copy()
-        df["ts_id"] = df[self._id_cols].apply(tuple, axis=1)
-        known_ids = set(self._pickled_models.keys())
-        ids = set(df["ts_id"].unique())
-        if not ids.issubset(known_ids):
-            raise MlflowException(
-                message=(
-                    f"Input data includes unseen values in id columns '{self._id_cols}'."
-                    f"Expected combined ids: {known_ids}\n"
-                    f"Got ids: {ids}\n"
-                ),
-                error_code=INVALID_PARAMETER_VALUE,
-            )
-        if self._preprocess_func and self._split_col:
-            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
-            # and the split column to be present, as they are used in the trial notebook. These columns are added 
-            # temporarily and removed after preprocessing.
-            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
-            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
-            df["y"] = None
-            df[self._split_col] = ""
-            df = df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)
-            df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
-        preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
-        df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
-        return df
 
     def _predict_single_id(self, df: pd.DataFrame) -> pd.DataFrame:
         id_ = df["ts_id"].to_list()[0]

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -74,9 +74,9 @@ class AbstractArimaModel(ForecastModel):
         :return: a DatetimeIndex.
         """
         ds_indices = pd.date_range(
-            start = start_ds,
-            periods = periods,
-            freq = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit]) * frequency_quantity
+            start=start_ds,
+            periods=periods,
+            freq=pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit]) * frequency_quantity
         )
         modified_start_ds = ds_indices.min()
         if start_ds != modified_start_ds:
@@ -158,21 +158,35 @@ class ArimaModel(AbstractArimaModel):
         future_pd = self._forecast(horizon, future_feature_df)
         if include_history:
             history_feature_df = self._get_history_feature_df(future_df)
-            in_sample_pd = self._predict_in_sample(start_ds = self._start_ds, end_ds = self._end_ds, feature_df = history_feature_df)
-            return pd.concat([in_sample_pd, future_pd]).reset_index(drop = True)
+            in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, feature_df=history_feature_df)
+            return pd.concat([in_sample_pd, future_pd]).reset_index(drop=True)
         else:
             return future_pd
 
     def _get_future_feature_df(self, future_df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Get the future feature dataframe.
+        :param future_df: A pd.Dataframe containing future time indices and future covariates if covariates are used in training.
+        :return: A pd.DataFrame with the future covariates, without the time column.
+        """
         if future_df is not None:
             time_col = self._time_col if self._time_col in future_df.columns else "ds"
-            return (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
+            future_feature_df = future_df[future_df[time_col] > self._end_ds].set_index(time_col)[self._exogenous_cols]
+            assert future_feature_df.empty == False, "future_feature_df is empty"
+            return future_feature_df
         else:
             return None
     
     def _get_history_feature_df(self, future_df: pd.DataFrame = None) -> pd.DataFrame:
+        """
+        Get the history feature dataframe.
+        :param future_df: A pd.Dataframe containing future time indices and future covariates if covariates are used in training.
+        :return: A pd.DataFrame with the history covariates, without the time column.
+        """
         if future_df is not None:
-            return future_df[future_df[self._time_col] <= self._end_ds].set_index(self._time_col)[self._exogenous_cols]
+            history_feature_df = future_df[future_df[self._time_col] <= self._end_ds].set_index(self._time_col)[self._exogenous_cols]
+            assert history_feature_df.empty == False, "history_feature_df is empty"
+            return history_feature_df
         else:
             return None
 
@@ -186,12 +200,12 @@ class ArimaModel(AbstractArimaModel):
         requested number of periods.
         """
         return make_single_future_dataframe(
-            start_time = self._start_ds,
-            end_time = self._end_ds,
-            horizon = horizon or self._horizon,
-            frequency_unit = self._frequency_unit,
-            frequency_quantity = self._frequency_quantity,
-            include_history = include_history
+            start_time=self._start_ds,
+            end_time=self._end_ds,
+            horizon=horizon or self._horizon,
+            frequency_unit=self._frequency_unit,
+            frequency_quantity=self._frequency_quantity,
+            include_history=include_history
         )
 
     def predict(self, context: mlflow.pyfunc.model.PythonModelContext, model_input: pd.DataFrame) -> pd.Series:
@@ -214,17 +228,17 @@ class ArimaModel(AbstractArimaModel):
         return result_df["yhat"]
 
     def _predict_impl(self, input_df: pd.DataFrame) -> pd.DataFrame:
-        df = input_df.rename(columns = {self._time_col: "ds"})
-        df["ds"] = pd.to_datetime(df["ds"], infer_datetime_format = True)
+        df = input_df.rename(columns={self._time_col: "ds"})
+        df["ds"] = pd.to_datetime(df["ds"], infer_datetime_format=True)
         # Validate the time range
         pred_start_ds = min(df["ds"])
         if pred_start_ds < self._start_ds:
             raise MlflowException(
-                message = (
+                message=(
                     f"Input time column '{self._time_col}' includes time earlier than "
                     "the history data that the model was trained on."
                 ),
-                error_code = INVALID_PARAMETER_VALUE,
+                error_code=INVALID_PARAMETER_VALUE,
             )
         # Check if the time has correct frequency
         consistency = df["ds"].apply(lambda x: 
@@ -232,10 +246,10 @@ class ArimaModel(AbstractArimaModel):
         ).all()
         if not consistency:
             raise MlflowException(
-                message = (
+                message=(
                     f"Input time column '{self._time_col}' includes different frequency."
                 ),
-                error_code = INVALID_PARAMETER_VALUE,
+                error_code=INVALID_PARAMETER_VALUE,
             )
         preds_pds = []
         # Out-of-sample prediction if needed
@@ -244,19 +258,19 @@ class ArimaModel(AbstractArimaModel):
             future_feature_df = df[df["ds"] > self._end_ds].set_index("ds")
             future_pd = self._forecast(
                 horizon,
-                feature_df = future_feature_df[self._exogenous_cols] if self._exogenous_cols else None)
+                feature_df=future_feature_df[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(future_pd)
         # In-sample prediction if needed
         if pred_start_ds <= self._end_ds:
             df_in_sample = df[df["ds"] <= self._end_ds].set_index("ds")
             in_sample_pd = self._predict_in_sample(
-                start_ds = pred_start_ds,
-                end_ds = self._end_ds,
-                feature_df = df_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
+                start_ds=pred_start_ds,
+                end_ds=self._end_ds,
+                feature_df=df_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(in_sample_pd)
         # Map predictions back to given timestamps
         preds_pd = pd.concat(preds_pds).set_index("ds")
-        df = df.set_index("ds").join(preds_pd, how = "left").reset_index()
+        df = df.set_index("ds").join(preds_pd, how="left").reset_index()
         return df
 
     def _predict_in_sample(
@@ -274,10 +288,10 @@ class ArimaModel(AbstractArimaModel):
         d = self.model().order[1]
         start_idx = max(start_idx, d)
         preds_in_sample, conf_in_sample = self.model().predict_in_sample(
-            X = feature_df,
-            start = start_idx,
-            end = end_idx,
-            return_conf_int = True)
+            X=feature_df,
+            start=start_idx,
+            end=end_idx,
+            return_conf_int=True)
         periods = calculate_period_differences(self._start_ds, end_ds, self._frequency_unit, self._frequency_quantity) + 1
         ds_indices = self._get_ds_indices(start_ds=self._start_ds, periods=periods, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[start_idx:]
         in_sample_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds_in_sample})
@@ -289,9 +303,12 @@ class ArimaModel(AbstractArimaModel):
         horizon: int = None,
         feature_df: pd.DataFrame = None) -> pd.DataFrame:
         """
-        
+        Do forecast for future data. feature_df should only contain future covariates, without the time column.
+        Unlike Prophet, pmdarima does not require time column in the feature_df, it depends on horizon to determine the length of the prediction
+        :param horizon: int number of periods to forecast forward.
+        :param feature_df: A pd.Dataframe with the future covariates, without the time column.
+        :return: A pd.DataFrame with the forecasts.
         """
-        # Unlike Prophet, pmdarima does not require time column in the feature_df, it depends on horizon to determine the length of the prediction
         # set horizon to the length of future_df if future_df is provided to avoid the length mismatch error from pmdarima
         if feature_df is None:
             horizon = horizon or self._horizon
@@ -299,9 +316,9 @@ class ArimaModel(AbstractArimaModel):
             horizon = len(feature_df)
         preds, conf = self.model().predict(
             horizon,
-            X = feature_df,
-            return_conf_int = True)
-        ds_indices = self._get_ds_indices(start_ds = self._end_ds, periods = horizon + 1, frequency_unit = self._frequency_unit, frequency_quantity = self._frequency_quantity)[1:]
+            X=feature_df,
+            return_conf_int=True)
+        ds_indices = self._get_ds_indices(start_ds=self._end_ds, periods=horizon + 1, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[1:]
         preds_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds})
         preds_pd[["yhat_lower", "yhat_upper"]] = conf
         return preds_pd
@@ -385,14 +402,14 @@ class MultiSeriesArimaModel(AbstractArimaModel):
             groups = list(self._pickled_models.keys())
 
         future_df = make_future_dataframe(
-            start_time = self._starts,
-            end_time = self._ends,
-            horizon = horizon,
-            frequency_unit = self._frequency_unit,
-            frequency_quantity = self._frequency_quantity,
-            include_history = include_history,
-            groups = groups,
-            identity_column_names = self._id_cols
+            start_time=self._starts,
+            end_time=self._ends,
+            horizon=horizon,
+            frequency_unit=self._frequency_unit,
+            frequency_quantity=self._frequency_quantity,
+            include_history=include_history,
+            groups=groups,
+            identity_column_names=self._id_cols
         )
         return future_df
 
@@ -415,7 +432,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
             # Add ts_id column to future_df because preprocess_func requires it
             future_df["ts_id"] = future_df[self._id_cols].apply(tuple, axis=1)
         preds_dfs = list(map(lambda id_: self._predict_timeseries_single_id(id_, horizon, include_history, future_df), ids))
-        return pd.concat(preds_dfs).reset_index(drop = True)
+        return pd.concat(preds_dfs).reset_index(drop=True)
 
     def _predict_timeseries_single_id(
         self,
@@ -449,16 +466,16 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         ids = set(df["ts_id"].unique())
         if not ids.issubset(known_ids):
             raise MlflowException(
-                message = (
+                message=(
                     f"Input data includes unseen values in id columns '{self._id_cols}'."
                     f"Expected combined ids: {known_ids}\n"
                     f"Got ids: {ids}\n"
                 ),
-                error_code = INVALID_PARAMETER_VALUE,
+                error_code=INVALID_PARAMETER_VALUE,
             )
         if self._preprocess_func and self._split_col:
             df = apply_preprocess_func(df, self._preprocess_func, self._split_col)
-        preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop = True)
+        preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
         df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
         return df["yhat"]
 
@@ -474,7 +491,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
                                            self._exogenous_cols,
                                            self._split_col,
                                            self._preprocess_func)
-        df["yhat"] = arima_model_single_id.predict(context = None, model_input = df).to_list()
+        df["yhat"] = arima_model_single_id.predict(context=None, model_input=df).to_list()
         return df
 
 

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -112,6 +112,8 @@ class ArimaModel(AbstractArimaModel):
         :param time_col: the column name of the time column
         :param exogenous_cols: Optional list of column names of exogenous variables. If provided, these columns are
         used as additional features in arima model.
+        :param split_col: Optional column name of the split column. It is only used for the preprocess_func.
+        :param preprocess_func: Optional function to preprocess the data. If provided, the data will be preprocessed before the model prediction.
         """
         super().__init__()
         self._pickled_model = pickled_model
@@ -312,6 +314,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         :param id_cols: the column names of the identity columns for multi-series time series
         :param exogenous_cols: Optional list of column names of exogenous variables. If provided, these columns are
         used as additional features in arima model.
+        :param split_col: Optional column name of the split column. It is only used for the preprocess_func.
+        :param preprocess_func: Optional function to preprocess the data. If provided, the data will be preprocessed before the model prediction.
         """
         super().__init__()
         self._pickled_models = pickled_model_dict

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -157,7 +157,7 @@ class ArimaModel(AbstractArimaModel):
             future_feature_df = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
         future_pd = self._forecast(horizon, future_feature_df)
         if include_history:
-            in_sample_pd = self._predict_in_sample(start_ds = self._start_ds, end_ds = self._end_ds, feature_df = future_feature_df)
+            in_sample_pd = self._predict_in_sample(start_ds = self._start_ds, end_ds = self._end_ds, feature_df = None)
             return pd.concat([in_sample_pd, future_pd]).reset_index(drop = True)
         else:
             return future_pd

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -151,6 +151,7 @@ class ArimaModel(AbstractArimaModel):
             future_df = apply_preprocess_func(future_df, self._preprocess_func, self._split_col)
         horizon = horizon or self._horizon
         future_feature_df = None
+        # TODO: investigate if we can use future_df directly in the forecast function
         if self._exogenous_cols and future_df is not None:
             time_col = self._time_col if self._time_col in future_df.columns else "ds"
             future_feature_df = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -74,9 +74,9 @@ class AbstractArimaModel(ForecastModel):
         :return: a DatetimeIndex.
         """
         ds_indices = pd.date_range(
-            start=start_ds,
-            periods=periods,
-            freq=pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit]) * frequency_quantity
+            start = start_ds,
+            periods = periods,
+            freq = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit]) * frequency_quantity
         )
         modified_start_ds = ds_indices.min()
         if start_ds != modified_start_ds:
@@ -157,8 +157,8 @@ class ArimaModel(AbstractArimaModel):
             future_feature_df = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
         future_pd = self._forecast(horizon, future_feature_df)
         if include_history:
-            in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, feature_df=future_feature_df)
-            return pd.concat([in_sample_pd, future_pd]).reset_index(drop=True)
+            in_sample_pd = self._predict_in_sample(start_ds = self._start_ds, end_ds = self._end_ds, feature_df = future_feature_df)
+            return pd.concat([in_sample_pd, future_pd]).reset_index(drop = True)
         else:
             return future_pd
 
@@ -172,12 +172,12 @@ class ArimaModel(AbstractArimaModel):
         requested number of periods.
         """
         return make_single_future_dataframe(
-            start_time=self._start_ds,
-            end_time=self._end_ds,
-            horizon=horizon or self._horizon,
-            frequency_unit=self._frequency_unit,
-            frequency_quantity=self._frequency_quantity,
-            include_history=include_history
+            start_time = self._start_ds,
+            end_time = self._end_ds,
+            horizon = horizon or self._horizon,
+            frequency_unit = self._frequency_unit,
+            frequency_quantity = self._frequency_quantity,
+            include_history = include_history
         )
 
     def predict(self, context: mlflow.pyfunc.model.PythonModelContext, model_input: pd.DataFrame) -> pd.Series:
@@ -200,17 +200,17 @@ class ArimaModel(AbstractArimaModel):
         return result_df["yhat"]
 
     def _predict_impl(self, input_df: pd.DataFrame) -> pd.DataFrame:
-        df = input_df.rename(columns={self._time_col: "ds"})
-        df["ds"] = pd.to_datetime(df["ds"], infer_datetime_format=True)
+        df = input_df.rename(columns = {self._time_col: "ds"})
+        df["ds"] = pd.to_datetime(df["ds"], infer_datetime_format = True)
         # Validate the time range
         pred_start_ds = min(df["ds"])
         if pred_start_ds < self._start_ds:
             raise MlflowException(
-                message=(
+                message = (
                     f"Input time column '{self._time_col}' includes time earlier than "
                     "the history data that the model was trained on."
                 ),
-                error_code=INVALID_PARAMETER_VALUE,
+                error_code = INVALID_PARAMETER_VALUE,
             )
         # Check if the time has correct frequency
         consistency = df["ds"].apply(lambda x: 
@@ -218,10 +218,10 @@ class ArimaModel(AbstractArimaModel):
         ).all()
         if not consistency:
             raise MlflowException(
-                message=(
+                message = (
                     f"Input time column '{self._time_col}' includes different frequency."
                 ),
-                error_code=INVALID_PARAMETER_VALUE,
+                error_code = INVALID_PARAMETER_VALUE,
             )
         preds_pds = []
         # Out-of-sample prediction if needed
@@ -230,19 +230,19 @@ class ArimaModel(AbstractArimaModel):
             future_feature_df = df[df["ds"] > self._end_ds].set_index("ds")
             future_pd = self._forecast(
                 horizon,
-                feature_df=future_feature_df[self._exogenous_cols] if self._exogenous_cols else None)
+                feature_df = future_feature_df[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(future_pd)
         # In-sample prediction if needed
         if pred_start_ds <= self._end_ds:
             df_in_sample = df[df["ds"] <= self._end_ds].set_index("ds")
             in_sample_pd = self._predict_in_sample(
-                start_ds=pred_start_ds,
-                end_ds=self._end_ds,
-                feature_df=df_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
+                start_ds = pred_start_ds,
+                end_ds = self._end_ds,
+                feature_df = df_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(in_sample_pd)
         # Map predictions back to given timestamps
         preds_pd = pd.concat(preds_pds).set_index("ds")
-        df = df.set_index("ds").join(preds_pd, how="left").reset_index()
+        df = df.set_index("ds").join(preds_pd, how = "left").reset_index()
         return df
 
     def _predict_in_sample(
@@ -260,10 +260,10 @@ class ArimaModel(AbstractArimaModel):
         d = self.model().order[1]
         start_idx = max(start_idx, d)
         preds_in_sample, conf_in_sample = self.model().predict_in_sample(
-            X=feature_df,
-            start=start_idx,
-            end=end_idx,
-            return_conf_int=True)
+            X = feature_df,
+            start = start_idx,
+            end = end_idx,
+            return_conf_int = True)
         periods = calculate_period_differences(self._start_ds, end_ds, self._frequency_unit, self._frequency_quantity) + 1
         ds_indices = self._get_ds_indices(start_ds=self._start_ds, periods=periods, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[start_idx:]
         in_sample_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds_in_sample})
@@ -276,12 +276,15 @@ class ArimaModel(AbstractArimaModel):
         feature_df: pd.DataFrame = None) -> pd.DataFrame:
         # Unlike Prophet, pmdarima does not require time column in the feature_df, it depends on horizon to determine the length of the prediction
         # set horizon to the length of future_df if future_df is provided to avoid the length mismatch error from pmdarima
-        horizon = horizon or self._horizon if feature_df is None else len(feature_df)
+        if feature_df is None:
+            horizon = horizon or self._horizon
+        else:
+            horizon = len(feature_df)
         preds, conf = self.model().predict(
             horizon,
-            X=feature_df,
-            return_conf_int=True)
-        ds_indices = self._get_ds_indices(start_ds=self._end_ds, periods=horizon + 1, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[1:]
+            X = feature_df,
+            return_conf_int = True)
+        ds_indices = self._get_ds_indices(start_ds = self._end_ds, periods = horizon + 1, frequency_unit = self._frequency_unit, frequency_quantity = self._frequency_quantity)[1:]
         preds_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds})
         preds_pd[["yhat_lower", "yhat_upper"]] = conf
         return preds_pd
@@ -365,14 +368,14 @@ class MultiSeriesArimaModel(AbstractArimaModel):
             groups = list(self._pickled_models.keys())
 
         future_df = make_future_dataframe(
-            start_time=self._starts,
-            end_time=self._ends,
-            horizon=horizon,
-            frequency_unit=self._frequency_unit,
-            frequency_quantity=self._frequency_quantity,
-            include_history=include_history,
-            groups=groups,
-            identity_column_names=self._id_cols
+            start_time = self._starts,
+            end_time = self._ends,
+            horizon = horizon,
+            frequency_unit = self._frequency_unit,
+            frequency_quantity = self._frequency_quantity,
+            include_history = include_history,
+            groups = groups,
+            identity_column_names = self._id_cols
         )
         return future_df
 
@@ -395,7 +398,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
             # Add ts_id column to future_df because preprocess_func requires it
             future_df["ts_id"] = future_df[self._id_cols].apply(tuple, axis=1)
         preds_dfs = list(map(lambda id_: self._predict_timeseries_single_id(id_, horizon, include_history, future_df), ids))
-        return pd.concat(preds_dfs).reset_index(drop=True)
+        return pd.concat(preds_dfs).reset_index(drop = True)
 
     def _predict_timeseries_single_id(
         self,
@@ -429,16 +432,16 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         ids = set(df["ts_id"].unique())
         if not ids.issubset(known_ids):
             raise MlflowException(
-                message=(
+                message = (
                     f"Input data includes unseen values in id columns '{self._id_cols}'."
                     f"Expected combined ids: {known_ids}\n"
                     f"Got ids: {ids}\n"
                 ),
-                error_code=INVALID_PARAMETER_VALUE,
+                error_code = INVALID_PARAMETER_VALUE,
             )
         if self._preprocess_func and self._split_col:
             df = apply_preprocess_func(df, self._preprocess_func, self._split_col)
-        preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
+        preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop = True)
         df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
         return df["yhat"]
 
@@ -454,7 +457,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
                                            self._exogenous_cols,
                                            self._split_col,
                                            self._preprocess_func)
-        df["yhat"] = arima_model_single_id.predict(context=None, model_input=df).to_list()
+        df["yhat"] = arima_model_single_id.predict(context = None, model_input = df).to_list()
         return df
 
 

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -140,27 +140,41 @@ class ArimaModel(AbstractArimaModel):
         include_history: bool = True,
         future_df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """
-        Predict target column for given horizon_timedelta and history data.
+        Predict target column for given horizon and history data.
         :param horizon: int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
-        :param future_df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
-        :return: A pd.DataFrame with the forecasts and confidence intervals for given horizon_timedelta and history data.
+        :param future_df: A pd.Dataframe containing future time indices and future covariates if covariates are used in training.
+        :return: A pd.DataFrame with the forecasts and confidence intervals for given horizon and history data.
         """
         if self._preprocess_func and self._split_col:
+            assert future_df is not None, "future_df is required when preprocess_func is provided"
             future_df = apply_preprocess_func(future_df, self._preprocess_func, self._split_col)
         horizon = horizon or self._horizon
         future_feature_df = None
         # TODO: investigate if we can use future_df directly in the forecast function
-        if self._exogenous_cols and future_df is not None:
-            time_col = self._time_col if self._time_col in future_df.columns else "ds"
-            future_feature_df = (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
+        if self._exogenous_cols:
+            future_feature_df = self._get_future_feature_df(future_df)
         future_pd = self._forecast(horizon, future_feature_df)
         if include_history:
-            in_sample_pd = self._predict_in_sample(start_ds = self._start_ds, end_ds = self._end_ds, feature_df = None)
+            history_feature_df = self._get_history_feature_df(future_df)
+            in_sample_pd = self._predict_in_sample(start_ds = self._start_ds, end_ds = self._end_ds, feature_df = history_feature_df)
             return pd.concat([in_sample_pd, future_pd]).reset_index(drop = True)
         else:
             return future_pd
+
+    def _get_future_feature_df(self, future_df: pd.DataFrame) -> pd.DataFrame:
+        if future_df is not None:
+            time_col = self._time_col if self._time_col in future_df.columns else "ds"
+            return (future_df[future_df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
+        else:
+            return None
+    
+    def _get_history_feature_df(self, future_df: pd.DataFrame = None) -> pd.DataFrame:
+        if future_df is not None:
+            return future_df[future_df[self._time_col] <= self._end_ds].set_index(self._time_col)[self._exogenous_cols]
+        else:
+            return None
 
     def make_future_dataframe(self, horizon: int = None, include_history: bool = True) -> pd.DataFrame:
         """
@@ -274,6 +288,9 @@ class ArimaModel(AbstractArimaModel):
         self,
         horizon: int = None,
         feature_df: pd.DataFrame = None) -> pd.DataFrame:
+        """
+        
+        """
         # Unlike Prophet, pmdarima does not require time column in the feature_df, it depends on horizon to determine the length of the prediction
         # set horizon to the length of future_df if future_df is provided to avoid the length mismatch error from pmdarima
         if feature_df is None:
@@ -385,7 +402,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         include_history: bool = True,
         future_df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """
-        Predict target column for given horizon_timedelta and history data.
+        Predict target column for given horizon and history data.
         :param horizon: Int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -197,13 +197,13 @@ class TestArimaModelWithExogenous(unittest.TestCase):
                                       exogenous_cols=self.exogenous_cols)
 
     def test_predict_timeseries_success(self):
-        forecast_pd = self.arima_model.predict_timeseries(df=self.df)
+        forecast_pd = self.arima_model.predict_timeseries(future_df=self.df)
         expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
         self.assertEqual(10, forecast_pd.shape[0])
         pd.testing.assert_series_equal(self.df["date"], forecast_pd["ds"], check_names=False)
         # Test forecast without history data
-        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, df=self.df)
+        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, future_df=self.df)
         self.assertEqual(len(forecast_future_pd), self.horizon)
 
     def test_predict_success(self):
@@ -345,7 +345,8 @@ class TestMultiSeriesArimaModelWithExogenous(unittest.TestCase):
             pd.to_datetime(pd.Series(range(num_rows), name="date").apply(lambda i: f"2020-{i + 1:02d}-13")),
             pd.Series(range(num_rows), name="y"),
             pd.Series(range(num_rows), name="x1"),
-            pd.Series(range(num_rows), name="x2")
+            pd.Series(range(num_rows), name="x2"),
+            pd.Series(["1" if i < 5 else "2" for i in range(num_rows)], name="id")  # Add id column with different values
         ], axis=1)
         train_df = self.df.set_index("date")
         self.exogenous_cols = ["x1", "x2"]
@@ -368,12 +369,12 @@ class TestMultiSeriesArimaModelWithExogenous(unittest.TestCase):
                                                  exogenous_cols=self.exogenous_cols)
 
     def test_predict_timeseries_success(self):
-        forecast_pd = self.arima_model.predict_timeseries(df=self.df)
+        forecast_pd = self.arima_model.predict_timeseries(future_df=self.df)
         expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
         self.assertEqual(18, forecast_pd.shape[0])
         # Test forecast without history data
-        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, df=self.df)
+        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, future_df=self.df)
         self.assertEqual(len(forecast_future_pd), 2)
 
     def test_predict_success(self):

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -632,10 +632,12 @@ class TestArimaModelWithPreprocess(unittest.TestCase):
         dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency_unit=self.freq, frequency_quantity=self.frequency_quantity)
         self.df = pd.concat([
             pd.Series(dates, name='date'),
-            pd.Series(range(self.num_rows), name="y")
+            pd.Series(range(self.num_rows), name="y"),
+            pd.Series(range(self.num_rows), name="x1"),
+            pd.Series(range(self.num_rows), name="x2")
         ], axis=1)
         model = ARIMA(order=(2, 0, 2), suppress_warnings=True)
-        model.fit(self.df.set_index("date"))
+        model.fit(self.df[["y", "date"]].set_index("date"), exogenous=self.df[["x1", "x2"]])
         pickled_model = pickle.dumps(model)
 
         # Create a mock preprocess function that doubles y values
@@ -653,18 +655,22 @@ class TestArimaModelWithPreprocess(unittest.TestCase):
                                      start_ds=self.start_ds,
                                      end_ds=pd.Timestamp("2020-11-26"),
                                      time_col="date",
+                                     exogenous_cols=["x1", "x2"],
                                      split_col="split",
                                      preprocess_func=self.mock_preprocess)
 
     def test_predict_timeseries_with_preprocess(self):
-        # Test with future_df that has y values
-        future_df = self.df.copy()
+        future_df = pd.DataFrame({
+            "date": [pd.to_datetime("2020-12-17"), pd.to_datetime("2020-12-24")],
+            "x1": [1, 2],
+            "x2": [3, 4]
+        })
         future_df["split"] = "prediction"
         
         forecast_pd = self.arima_model.predict_timeseries(future_df=future_df)
         expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
-        self.assertEqual(10, forecast_pd.shape[0])
+        self.assertEqual(11, forecast_pd.shape[0])
         
         # Verify that preprocess_func was called with the correct argument
         self.mock_preprocess.assert_called_once()
@@ -687,7 +693,9 @@ class TestArimaModelWithPreprocess(unittest.TestCase):
 
     def test_predict_with_preprocess(self):
         test_df = pd.DataFrame({
-            "date": [pd.to_datetime("2020-10-08"), pd.to_datetime("2020-12-10")]
+            "date": [pd.to_datetime("2020-12-17"), pd.to_datetime("2020-12-24")],
+            "x1": [1, 2],
+            "x2": [3, 4]
         })
         
         yhat = self.arima_model.predict(context=None, model_input=test_df)

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -17,6 +17,7 @@
 import unittest
 import pickle
 import datetime
+from unittest import mock
 
 import mlflow
 import pytest
@@ -620,3 +621,158 @@ class TestArimaModelFrequencyQuantity(unittest.TestCase):
             with pytest.raises(MlflowException, match="Input data columns") as e:
                 arima_model.predict(context=None, model_input=test_df)
             assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+class TestArimaModelWithPreprocess(unittest.TestCase):
+    def setUp(self) -> None:
+        self.num_rows = 9
+        self.start_ds = pd.Timestamp("2020-10-01")
+        self.horizon = 1
+        self.freq = 'W'
+        self.frequency_quantity = 1
+        dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency_unit=self.freq, frequency_quantity=self.frequency_quantity)
+        self.df = pd.concat([
+            pd.Series(dates, name='date'),
+            pd.Series(range(self.num_rows), name="y")
+        ], axis=1)
+        model = ARIMA(order=(2, 0, 2), suppress_warnings=True)
+        model.fit(self.df.set_index("date"))
+        pickled_model = pickle.dumps(model)
+
+        # Create a mock preprocess function that doubles y values
+        def preprocess_func(df):
+            df = df.copy()
+            df["y"] = df["y"] * 2
+            return df
+        
+        self.mock_preprocess = mock.Mock(side_effect=preprocess_func)
+
+        self.arima_model = ArimaModel(pickled_model,
+                                     horizon=self.horizon,
+                                     frequency_unit=self.freq,
+                                     frequency_quantity=self.frequency_quantity,
+                                     start_ds=self.start_ds,
+                                     end_ds=pd.Timestamp("2020-11-26"),
+                                     time_col="date",
+                                     split_col="split",
+                                     preprocess_func=self.mock_preprocess)
+
+    def test_predict_timeseries_with_preprocess(self):
+        # Test with future_df that has y values
+        future_df = self.df.copy()
+        future_df["split"] = "prediction"
+        
+        forecast_pd = self.arima_model.predict_timeseries(future_df=future_df)
+        expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
+        self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
+        self.assertEqual(10, forecast_pd.shape[0])
+        
+        # Verify that preprocess_func was called with the correct argument
+        self.mock_preprocess.assert_called_once()
+        call_arg = self.mock_preprocess.call_args[0][0]
+        
+        # Verify the structure of the dataframe passed to preprocess_func
+        expected_call = future_df.copy()
+        expected_call["y"] = None
+        expected_call["split"] = "prediction"
+        pd.testing.assert_frame_equal(call_arg, expected_call)
+        
+        # Verify the return value from preprocess_func
+        # The preprocess function doubles y values
+        expected_return = expected_call.copy()
+        expected_return["y"] = expected_return["y"] * 2 if expected_return["y"] is not None else 0
+        
+        # Get the actual return value from the call
+        actual_return = self.mock_preprocess.side_effect(call_arg)
+        pd.testing.assert_frame_equal(actual_return, expected_return)
+
+    def test_predict_with_preprocess(self):
+        test_df = pd.DataFrame({
+            "date": [pd.to_datetime("2020-10-08"), pd.to_datetime("2020-12-10")]
+        })
+        
+        yhat = self.arima_model.predict(context=None, model_input=test_df)
+        self.assertEqual(2, len(yhat))
+        
+        # Verify that preprocess_func was called with the correct argument
+        self.mock_preprocess.assert_called_once()
+        call_arg = self.mock_preprocess.call_args[0][0]
+        
+        # Verify the structure of the dataframe passed to preprocess_func
+        expected_call = test_df.copy()
+        expected_call["y"] = None
+        expected_call["split"] = "prediction"
+        pd.testing.assert_frame_equal(call_arg, expected_call)
+        
+        # Verify the return value from preprocess_func
+        # The preprocess function doubles y values
+        expected_return = expected_call.copy()
+        expected_return["y"] = expected_return["y"] * 2 if expected_return["y"] is not None else 0
+        
+        # Get the actual return value from the call
+        actual_return = self.mock_preprocess.side_effect(call_arg)
+        pd.testing.assert_frame_equal(actual_return, expected_return)
+
+class TestMultiSeriesArimaModelWithPreprocess(unittest.TestCase):
+    def setUp(self) -> None:
+        num_rows = 9
+        self.df = pd.concat([
+            pd.to_datetime(pd.Series(range(num_rows), name="date").apply(lambda i: f"2020-{i + 1:02d}-13")),
+            pd.Series(range(num_rows), name="y")
+        ], axis=1)
+        model = ARIMA(order=(2, 0, 2), suppress_warnings=True)
+        model.fit(self.df.set_index("date"))
+        self.pickled_model = pickle.dumps(model)
+        pickled_model_dict = {("1",): self.pickled_model, ("2",): self.pickled_model}
+        start_ds_dict = {("1",): pd.Timestamp("2020-01-13"), ("2",): pd.Timestamp("2020-01-13")}
+        end_ds_dict = {("1",): pd.Timestamp("2020-09-13"), ("2",): pd.Timestamp("2020-09-13")}
+
+        # Create a mock preprocess function that adds 1 to y values
+        def preprocess_func(df):
+            df = df.copy()
+            df["y"] = df["y"] + 1
+            return df
+        
+        self.mock_preprocess = mock.Mock(side_effect=preprocess_func)
+
+        self.arima_model = MultiSeriesArimaModel(pickled_model_dict,
+                                                horizon=1,
+                                                frequency_unit='month',
+                                                frequency_quantity=1,
+                                                start_ds_dict=start_ds_dict,
+                                                end_ds_dict=end_ds_dict,
+                                                time_col="date",
+                                                id_cols=["id"],
+                                                split_col="split",
+                                                preprocess_func=self.mock_preprocess)
+
+    def test_predict_with_preprocess(self):
+        test_df = pd.DataFrame({
+            "date": [pd.to_datetime("2020-05-13"), pd.to_datetime("2020-05-13"),
+                     pd.to_datetime("2020-12-13"), pd.to_datetime("2020-12-13")],
+            "id": ["1", "2", "1", "2"]
+        })
+        
+        yhat = self.arima_model.predict(context=None, model_input=test_df)
+        self.assertEqual(4, len(yhat))
+        
+        # Verify that preprocess_func was called three times:
+        # 1. In predict() for the entire dataframe
+        # 2. For each time series (id=1 and id=2)
+        self.assertEqual(len(self.mock_preprocess.call_args_list), 3)
+        
+        # First call: entire dataframe
+        first_call_arg = self.mock_preprocess.call_args_list[0][0][0]
+        expected_first_call = test_df.copy()
+        expected_first_call["ts_id"] = expected_first_call[["id"]].apply(tuple, axis=1)
+        expected_first_call["y"] = None
+        expected_first_call["split"] = "prediction"
+        pd.testing.assert_frame_equal(first_call_arg, expected_first_call)
+        
+        # Verify the return value from preprocess_func
+        # The preprocess function adds 1 to y values
+        expected_return = expected_first_call.copy()
+        expected_return["y"] = expected_return["y"] + 1 if expected_return["y"] is not None else 1
+        
+        # Get the actual return value from the first call
+        actual_return = self.mock_preprocess.side_effect(first_call_arg)
+        pd.testing.assert_frame_equal(actual_return, expected_return)

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -660,11 +660,12 @@ class TestArimaModelWithPreprocess(unittest.TestCase):
                                      preprocess_func=self.mock_preprocess)
 
     def test_predict_timeseries_with_preprocess(self):
-        future_df = pd.DataFrame({
+        future_df = self.df.copy()
+        future_df = pd.concat([future_df, pd.DataFrame({
             "date": [pd.to_datetime("2020-12-17"), pd.to_datetime("2020-12-24")],
             "x1": [1, 2],
             "x2": [3, 4]
-        })
+        })], axis=0)
         future_df["split"] = "prediction"
         
         forecast_pd = self.arima_model.predict_timeseries(future_df=future_df)


### PR DESCRIPTION
This PR modifies model.py under ARIMA to support inference with covariates. In details, it
1. adds the usage preprocess_func in predict
2. modifies the function argument for predict_timeseries to align with Prophet