### PR TITLE
[ML-52204] Do not concatenate multiple time series id keys for DeepAR

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -121,7 +121,6 @@ class DeepARModel(ForecastModel):
         if num_samples is None:
             num_samples = self._num_samples
 
-        print("Debug:enter predict_samples")
         # Group by the time column in case there are multiple rows for each time column,
         # for example, the user didn't provide all the identity columns for a multi-series dataset
         group_cols = [self._time_col]
@@ -135,14 +134,10 @@ class DeepARModel(ForecastModel):
                                                                         self._frequency_quantity,
                                                                         self._id_cols)
 
-        print(f"Debug model_input_transformed keys type: {type(model_input_transformed)}")
         test_ds = PandasDataset(model_input_transformed, target=self._target_col)
 
         forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
         forecast_sample_list = list(forecast_iter)
-
-        for forecast in forecast_sample_list:
-            print(f"Debug forecast.item_id type: {type(forecast.item_id)}")
 
         return forecast_sample_list
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -100,7 +100,7 @@ class DeepARModel(ForecastModel):
 
         pred_df = pred_df.rename(columns={'index': self._time_col})
         if self._id_cols:
-            id_col_name = '-'.join(self._id_cols)
+            id_col_name = self._id_cols[0]
             pred_df = pred_df.rename(columns={'item_id': id_col_name})
         else:
             pred_df = pred_df.drop(columns='item_id')
@@ -121,6 +121,7 @@ class DeepARModel(ForecastModel):
         if num_samples is None:
             num_samples = self._num_samples
 
+        print("Debug:enter predict_samples")
         # Group by the time column in case there are multiple rows for each time column,
         # for example, the user didn't provide all the identity columns for a multi-series dataset
         group_cols = [self._time_col]
@@ -134,10 +135,14 @@ class DeepARModel(ForecastModel):
                                                                         self._frequency_quantity,
                                                                         self._id_cols)
 
+        print(f"Debug model_input_transformed keys type: {type(model_input_transformed)}")
         test_ds = PandasDataset(model_input_transformed, target=self._target_col)
 
         forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
         forecast_sample_list = list(forecast_iter)
+
+        for forecast in forecast_sample_list:
+            print(f"Debug forecast.item_id type: {type(forecast.item_id)}")
 
         return forecast_sample_list
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -98,9 +98,11 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
         df_dict = {}
         for grouped_id, grouped_df in df.groupby(id_cols):
             if isinstance(grouped_id, tuple):
+                # TODO (ML-52171): Fix the DeepAR library to support multi-time series id columns
+                # For now, we convert and concatenate the id_cols to a string
                 ts_id = "-".join([str(x) for x in grouped_id])
             else:
-                ts_id = str(grouped_id)
+                ts_id = grouped_id
             df_dict[ts_id] = (grouped_df.set_index(time_col).sort_index()
                               .reindex(valid_index).drop(id_cols, axis=1))
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -86,7 +86,7 @@ def set_index_and_fill_missing_time_steps(
              multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
     """
     total_min, total_max = df[time_col].min(), df[time_col].max()
-    print("Debug:linyuan")
+
     # We need to adjust the frequency_unit for pd.date_range if it is weekly,
     # otherwise it would always be "W-SUN"
     if frequency_unit.upper() == "W":
@@ -104,17 +104,18 @@ def set_index_and_fill_missing_time_steps(
                 # TODO (ML-52171): Fix the DeepAR library to support multi-time series id columns
                 # For now, DeepAR is dropped for multiple id_cols
                 raise ValueError("DeepAR does not support multiple time series id columns")
-            print(f"Debug groupe_id type: {type(grouped_id)}")
             df_dict[grouped_id] = (grouped_df.set_index(time_col).sort_index()
                                    .reindex(valid_index).drop(id_cols, axis=1))
 
         return df_dict
-    else:
-        df = df.set_index(time_col).sort_index()
-        # Fill in missing time steps between the min and max time steps
-        df = df.reindex(valid_index)
-        return df
+
+    df = df.set_index(time_col).sort_index()
+
+    # Fill in missing time steps between the min and max time steps
+    df = df.reindex(valid_index)
 
     if frequency_unit.upper() == "MS":
         # Truncate the day of month to avoid issues with pandas frequency check
         df = df.to_period("M")
+
+    return df

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -13,10 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List, Optional
+from typing import List, Optional, Union, Dict
 
 import pandas as pd
-
 
 def validate_and_generate_index(df: pd.DataFrame, 
                                 time_col: str, 
@@ -66,10 +65,12 @@ def validate_and_generate_index(df: pd.DataFrame,
 
     return new_index_full
 
-def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
-                                          frequency_unit: str,
-                                          frequency_quantity: int,
-                                          id_cols: Optional[List[str]] = None):
+def set_index_and_fill_missing_time_steps(
+        df: pd.DataFrame, time_col: str,
+        frequency_unit: str,
+        frequency_quantity: int,
+        id_cols: Optional[List[str]] = None
+) -> Union[pd.DataFrame, Dict[any, pd.DataFrame]]:
     """
     Transform the input dataframe to an acceptable format for the GluonTS library.
 
@@ -85,7 +86,7 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
              multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
     """
     total_min, total_max = df[time_col].min(), df[time_col].max()
-
+    print("Debug:linyuan")
     # We need to adjust the frequency_unit for pd.date_range if it is weekly,
     # otherwise it would always be "W-SUN"
     if frequency_unit.upper() == "W":
@@ -95,26 +96,25 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
     valid_index = validate_and_generate_index(df=df, time_col=time_col, frequency_unit=frequency_unit, frequency_quantity=frequency_quantity)
 
     if id_cols is not None:
+        if len(id_cols) > 1:
+            raise ValueError("DeepAR does not support multiple time series id columns")
         df_dict = {}
         for grouped_id, grouped_df in df.groupby(id_cols):
             if isinstance(grouped_id, tuple):
                 # TODO (ML-52171): Fix the DeepAR library to support multi-time series id columns
-                # For now, we convert and concatenate the id_cols to a string
-                ts_id = "-".join([str(x) for x in grouped_id])
-            else:
-                ts_id = grouped_id
-            df_dict[ts_id] = (grouped_df.set_index(time_col).sort_index()
-                              .reindex(valid_index).drop(id_cols, axis=1))
+                # For now, DeepAR is dropped for multiple id_cols
+                raise ValueError("DeepAR does not support multiple time series id columns")
+            print(f"Debug groupe_id type: {type(grouped_id)}")
+            df_dict[grouped_id] = (grouped_df.set_index(time_col).sort_index()
+                                   .reindex(valid_index).drop(id_cols, axis=1))
 
         return df_dict
-
-    df = df.set_index(time_col).sort_index()
-
-    # Fill in missing time steps between the min and max time steps
-    df = df.reindex(valid_index)
+    else:
+        df = df.set_index(time_col).sort_index()
+        # Fill in missing time steps between the min and max time steps
+        df = df.reindex(valid_index)
+        return df
 
     if frequency_unit.upper() == "MS":
         # Truncate the day of month to avoid issues with pandas frequency check
         df = df.to_period("M")
-
-    return df


### PR DESCRIPTION
As a short-term solution, we don't allow DeepAR to train multiple time series with multiple time series ids.