### PR TITLE
[ES-1492101] Add category_encoders to model dependency

### DIFF
--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -23,12 +23,17 @@ from gluonts.torch.model.predictor import PyTorchPredictor
 from mlflow.utils.environment import _mlflow_conda_env
 
 from databricks.automl_runtime.forecast.model import ForecastModel, mlflow_forecast_log_model
+from databricks.automl_runtime import version
+
+
+DEEPAR_ADDITIONAL_PIP_DEPS = [
+    f"gluonts[torch]=={gluonts.__version__}",
+    f"pandas=={pd.__version__}",
+    f"databricks-automl-runtime=={version.__version__}"
+]
 
 DEEPAR_CONDA_ENV = _mlflow_conda_env(
-    additional_pip_deps=[
-        f"gluonts[torch]=={gluonts.__version__}",
-        f"pandas=={pd.__version__}",
-    ]
+    additional_pip_deps=DEEPAR_ADDITIONAL_PIP_DEPS
 )
 
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -77,7 +77,7 @@ class DeepARModel(ForecastModel):
         :return: predicted pd.DataFrame that starts after the last timestamp in the input dataframe,
                                 and predicts the horizon using the mean of the samples
         """
-        required_cols = [self._target_col, self._time_col]
+        required_cols = [self._time_col]
         if self._id_cols:
             required_cols += self._id_cols
         self._validate_cols(model_input, required_cols)

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -1,0 +1,137 @@
+#
+# Copyright (C) 2024 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import List, Optional
+
+import gluonts
+import mlflow
+import pandas as pd
+from gluonts.dataset.pandas import PandasDataset
+from gluonts.torch.model.predictor import PyTorchPredictor
+from mlflow.utils.environment import _mlflow_conda_env
+
+from databricks.automl_runtime.forecast.model import ForecastModel, mlflow_forecast_log_model
+
+DEEPAR_CONDA_ENV = _mlflow_conda_env(
+    additional_pip_deps=[
+        f"gluonts[torch]=={gluonts.__version__}",
+        f"pandas=={pd.__version__}",
+    ]
+)
+
+
+class DeepARModel(ForecastModel):
+    """
+    DeepAR mlflow model wrapper for forecasting.
+    """
+
+    def __init__(self, model: PyTorchPredictor, horizon: int, num_samples: int,
+                 target_col: str, time_col: str,
+                 id_cols: Optional[List[str]] = None) -> None:
+        """
+        Initialize the DeepAR mlflow Python model wrapper
+        :param model: DeepAR model
+        :param horizon: the number of periods to forecast forward
+        :param num_samples: the number of samples to draw from the distribution
+        :param target_col: the target column name
+        :param time_col: the time column name
+        :param id_cols: the column names of the identity columns for multi-series time series; None for single series
+        """
+
+        # TODO: combine id_cols in predict() to ts_id when there are multiple id_cols
+        if id_cols and len(id_cols) > 1:
+            raise NotImplementedError("Logging multiple id_cols for DeepAR in AutoML are not supported yet")
+
+        super().__init__()
+        self._model = model
+        self._horizon = horizon
+        self._num_samples = num_samples
+        self._target_col = target_col
+        self._time_col = time_col
+        self._id_cols = id_cols
+
+    @property
+    def model_env(self):
+        return DEEPAR_CONDA_ENV
+
+    def predict(self,
+                context: mlflow.pyfunc.model.PythonModelContext,
+                model_input: pd.DataFrame) -> pd.DataFrame:
+        """
+        Predict the future dataframe given the history dataframe
+        :param context: A :class:`~PythonModelContext` instance containing artifacts that the model
+                        can use to perform inference.
+        :param model_input: Input dataframe that contains the history data
+        :return: predicted pd.DataFrame that starts after the last timestamp in the input dataframe,
+                                and predicts the horizon using the mean of the samples
+        """
+        required_cols = [self._target_col, self._time_col]
+        if self._id_cols:
+            required_cols += self._id_cols
+        self._validate_cols(model_input, required_cols)
+
+        forecast_sample_list = self.predict_samples(model_input, num_samples=self._num_samples)
+
+        pred_df = pd.concat(
+            [
+                forecast.mean_ts.rename('yhat').reset_index().assign(item_id=forecast.item_id)
+                for forecast in forecast_sample_list
+            ],
+            ignore_index=True
+        )
+
+        pred_df = pred_df.rename(columns={'index': self._time_col})
+        if self._id_cols:
+            pred_df = pred_df.rename(columns={'item_id': self._id_cols[0]})
+        else:
+            pred_df = pred_df.drop(columns='item_id')
+
+        pred_df[self._time_col] = pred_df[self._time_col].dt.to_timestamp()
+
+        return pred_df
+
+    def predict_samples(self,
+                        model_input: pd.DataFrame,
+                        num_samples: int = None) -> List[gluonts.model.forecast.SampleForecast]:
+        """
+        Predict the future samples given the history dataframe
+        :param model_input: Input dataframe that contains the history data
+        :param num_samples: the number of samples to draw from the distribution
+        :return: List of SampleForecast, where each SampleForecast contains num_samples sampled forecasts
+        """
+        if num_samples is None:
+            num_samples = self._num_samples
+
+        model_input = model_input.set_index(self._time_col)
+        if self._id_cols:
+            test_ds = PandasDataset.from_long_dataframe(model_input, target=self._target_col,
+                                                        item_id=self._id_cols[0], unchecked=True)
+        else:
+            test_ds = PandasDataset(model_input, target=self._target_col)
+
+        forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
+        forecast_sample_list = list(forecast_iter)
+
+        return forecast_sample_list
+
+
+def mlflow_deepar_log_model(deepar_model: DeepARModel,
+                            sample_input: pd.DataFrame = None) -> None:
+    """
+    Log the DeepAR model to mlflow
+    :param deepar_model: DeepAR mlflow PythonModel wrapper
+    :param sample_input: sample input Dataframes for model inference
+    """
+    mlflow_forecast_log_model(deepar_model, sample_input)

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -77,7 +77,7 @@ class DeepARModel(ForecastModel):
         :return: predicted pd.DataFrame that starts after the last timestamp in the input dataframe,
                                 and predicts the horizon using the mean of the samples
         """
-        required_cols = [self._time_col]
+        required_cols = [self._target_col, self._time_col]
         if self._id_cols:
             required_cols += self._id_cols
         self._validate_cols(model_input, required_cols)

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -15,6 +15,7 @@
 #
 from typing import List, Optional
 
+import category_encoders
 import gluonts
 import mlflow
 import pandas as pd
@@ -29,6 +30,7 @@ from databricks.automl_runtime.forecast.deepar.utils import set_index_and_fill_m
 DEEPAR_ADDITIONAL_PIP_DEPS = [
     f"gluonts[torch]=={gluonts.__version__}",
     f"pandas=={pd.__version__}",
+    f"category_encoders=={category_encoders.__version__}",
     f"databricks-automl-runtime=={version.__version__}"
 ]
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -124,7 +124,7 @@ class DeepARModel(ForecastModel):
                                                                         self._frequency,
                                                                         self._id_cols)
 
-        test_ds = PandasDataset(model_input_transformed, target=self._target_col)
+        test_ds = PandasDataset(model_input_transformed, target=self._target_col, freq=self._frequency)
 
         forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
         forecast_sample_list = list(forecast_iter)

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -42,7 +42,7 @@ class DeepARModel(ForecastModel):
     DeepAR mlflow model wrapper for forecasting.
     """
 
-    def __init__(self, model: PyTorchPredictor, horizon: int, frequency: str,
+    def __init__(self, model: PyTorchPredictor, horizon: int, frequency_unit: str, frequency_quantity: int,
                  num_samples: int,
                  target_col: str, time_col: str,
                  id_cols: Optional[List[str]] = None) -> None:
@@ -50,7 +50,8 @@ class DeepARModel(ForecastModel):
         Initialize the DeepAR mlflow Python model wrapper
         :param model: DeepAR model
         :param horizon: the number of periods to forecast forward
-        :param frequency: the frequency of the time series
+        :param frequency_unit: the frequency unit of the time series
+        :param frequency_quantity: the frequency quantity of the time series
         :param num_samples: the number of samples to draw from the distribution
         :param target_col: the target column name
         :param time_col: the time column name
@@ -60,7 +61,8 @@ class DeepARModel(ForecastModel):
         super().__init__()
         self._model = model
         self._horizon = horizon
-        self._frequency = frequency
+        self._frequency_unit = frequency_unit
+        self._frequency_quantity = frequency_quantity
         self._num_samples = num_samples
         self._target_col = target_col
         self._time_col = time_col
@@ -128,7 +130,8 @@ class DeepARModel(ForecastModel):
 
         model_input_transformed = set_index_and_fill_missing_time_steps(model_input,
                                                                         self._time_col,
-                                                                        self._frequency,
+                                                                        self._frequency_unit,
+                                                                        self._frequency_quantity,
                                                                         self._id_cols)
 
         test_ds = PandasDataset(model_input_transformed, target=self._target_col)

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -131,7 +131,7 @@ class DeepARModel(ForecastModel):
                                                                         self._frequency,
                                                                         self._id_cols)
 
-        test_ds = PandasDataset(model_input_transformed, target=self._target_col, freq=self._frequency)
+        test_ds = PandasDataset(model_input_transformed, target=self._target_col)
 
         forecast_iter = self._model.predict(test_ds, num_samples=num_samples)
         forecast_sample_list = list(forecast_iter)

--- a/runtime/databricks/automl_runtime/forecast/deepar/model.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/model.py
@@ -119,6 +119,13 @@ class DeepARModel(ForecastModel):
         if num_samples is None:
             num_samples = self._num_samples
 
+        # Group by the time column in case there are multiple rows for each time column,
+        # for example, the user didn't provide all the identity columns for a multi-series dataset
+        group_cols = [self._time_col]
+        if self._id_cols:
+            group_cols += self._id_cols
+        model_input = model_input.groupby(group_cols).agg({self._target_col: "mean"}).reset_index()
+
         model_input_transformed = set_index_and_fill_missing_time_steps(model_input,
                                                                         self._time_col,
                                                                         self._frequency,

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2024 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import List, Optional
+
+import pandas as pd
+
+
+def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
+                                          frequency: str,
+                                          id_cols: Optional[List[str]] = None):
+    """
+    Transform the input dataframe to an acceptable format for the GluonTS library.
+
+    - Set the time column as the index
+    - Impute missing time steps between the min and max time steps
+
+    :param df: the input dataframe that contains time_col
+    :param time_col: time column name
+    :param frequency: the frequency of the time series
+    :param id_cols: the column names of the identity columns for multi-series time series; None for single series
+    :return: single-series - transformed dataframe;
+             multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
+    """
+    total_min, total_max = df[time_col].min(), df[time_col].max()
+    new_index_full = pd.date_range(total_min, total_max, freq=frequency)
+
+    if id_cols is not None:
+        df_dict = {}
+        for grouped_id, grouped_df in df.groupby(id_cols):
+            if isinstance(grouped_id, tuple):
+                ts_id = "-".join([str(x) for x in grouped_id])
+            else:
+                ts_id = str(grouped_id)
+            df_dict[ts_id] = (grouped_df.set_index(time_col).sort_index()
+                              .reindex(new_index_full).drop(id_cols, axis=1))
+
+        return df_dict
+
+    df = df.set_index(time_col).sort_index()
+
+    # Fill in missing time steps between the min and max time steps
+    return df.reindex(new_index_full)

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -18,7 +18,10 @@ from typing import List, Optional
 import pandas as pd
 
 
-def validate_and_generate_index(df: pd.DataFrame, time_col: str, frequency: str):
+def validate_and_generate_index(df: pd.DataFrame, 
+                                time_col: str, 
+                                frequency_unit: str, 
+                                frequency_quantity: int):
     """
     Generate a complete time index for the given DataFrame based on the specified frequency.
     - Ensures the time column is in datetime format.
@@ -26,12 +29,13 @@ def validate_and_generate_index(df: pd.DataFrame, time_col: str, frequency: str)
     - Generates a new time index from the minimum to the maximum timestamp in the data.
     :param df: The input DataFrame containing the time column.
     :param time_col: The name of the time column.
-    :param frequency: The frequency of the time series.
+    :param frequency_unit: The frequency unit of the time series.
+    :param frequency_quantity: The frequency quantity of the time series.
     :return: A complete time index covering the full range of the dataset.
     :raises ValueError: If the day-of-month pattern is inconsistent for "MS" frequency.
     """
-    if frequency.upper() != "MS":
-        return pd.date_range(df[time_col].min(), df[time_col].max(), freq=frequency)
+    if frequency_unit.upper() != "MS":
+        return pd.date_range(df[time_col].min(), df[time_col].max(), freq=f"{frequency_quantity}{frequency_unit}")
 
     df[time_col] = pd.to_datetime(df[time_col])  # Ensure datetime format
 
@@ -63,7 +67,8 @@ def validate_and_generate_index(df: pd.DataFrame, time_col: str, frequency: str)
     return new_index_full
 
 def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
-                                          frequency: str,
+                                          frequency_unit: str,
+                                          frequency_quantity: int,
                                           id_cols: Optional[List[str]] = None):
     """
     Transform the input dataframe to an acceptable format for the GluonTS library.
@@ -73,20 +78,21 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
 
     :param df: the input dataframe that contains time_col
     :param time_col: time column name
-    :param frequency: the frequency of the time series
+    :param frequency_unit: the frequency unit of the time series
+    :param frequency_quantity: the frequency quantity of the time series
     :param id_cols: the column names of the identity columns for multi-series time series; None for single series
     :return: single-series - transformed dataframe;
              multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
     """
     total_min, total_max = df[time_col].min(), df[time_col].max()
 
-    # We need to adjust the frequency for pd.date_range if it is weekly,
+    # We need to adjust the frequency_unit for pd.date_range if it is weekly,
     # otherwise it would always be "W-SUN"
-    if frequency.upper() == "W":
+    if frequency_unit.upper() == "W":
         weekday_name = total_min.strftime("%a").upper() # e.g., "FRI"
-        frequency = f"W-{weekday_name}"
+        frequency_unit = f"W-{weekday_name}"
 
-    new_index_full = validate_and_generate_index(df=df, time_col=time_col, frequency=frequency)
+    valid_index = validate_and_generate_index(df=df, time_col=time_col, frequency_unit=frequency_unit, frequency_quantity=frequency_quantity)
 
     if id_cols is not None:
         df_dict = {}
@@ -96,16 +102,16 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
             else:
                 ts_id = str(grouped_id)
             df_dict[ts_id] = (grouped_df.set_index(time_col).sort_index()
-                              .reindex(new_index_full).drop(id_cols, axis=1))
+                              .reindex(valid_index).drop(id_cols, axis=1))
 
         return df_dict
 
     df = df.set_index(time_col).sort_index()
 
     # Fill in missing time steps between the min and max time steps
-    df = df.reindex(new_index_full)
+    df = df.reindex(valid_index)
 
-    if frequency.upper() == "MS":
+    if frequency_unit.upper() == "MS":
         # Truncate the day of month to avoid issues with pandas frequency check
         df = df.to_period("M")
 

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -85,7 +85,6 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
              multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
     """
     total_min, total_max = df[time_col].min(), df[time_col].max()
-
     # We need to adjust the frequency_unit for pd.date_range if it is weekly,
     # otherwise it would always be "W-SUN"
     if frequency_unit.upper() == "W":
@@ -103,16 +102,19 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
                 ts_id = str(grouped_id)
             df_dict[ts_id] = (grouped_df.set_index(time_col).sort_index()
                               .reindex(valid_index).drop(id_cols, axis=1))
+            if frequency_unit.upper() == "MS":
+                # Truncate the day of month to avoid issues with pandas frequency check
+                df_dict[ts_id] = df_dict[ts_id].to_period("M")
 
         return df_dict
+    else:
+        df = df.set_index(time_col).sort_index()
 
-    df = df.set_index(time_col).sort_index()
+        # Fill in missing time steps between the min and max time steps
+        df = df.reindex(valid_index)
 
-    # Fill in missing time steps between the min and max time steps
-    df = df.reindex(valid_index)
+        if frequency_unit.upper() == "MS":
+            # Truncate the day of month to avoid issues with pandas frequency check
+            df = df.to_period("M")
 
-    if frequency_unit.upper() == "MS":
-        # Truncate the day of month to avoid issues with pandas frequency check
-        df = df.to_period("M")
-
-    return df
+        return df

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -35,6 +35,13 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
              multi-series - dictionary of transformed dataframes, each key is the (concatenated) id of the time series
     """
     total_min, total_max = df[time_col].min(), df[time_col].max()
+
+    # We need to adjust the frequency for pd.date_range if it is weekly,
+    # otherwise it would always be "W-SUN"
+    if frequency.upper() == "W":
+        weekday_name = total_min.strftime("%a").upper() # e.g., "FRI"
+        frequency = f"W-{weekday_name}"
+
     new_index_full = pd.date_range(total_min, total_max, freq=frequency)
 
     if id_cols is not None:

--- a/runtime/databricks/automl_runtime/forecast/deepar/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/deepar/utils.py
@@ -18,6 +18,50 @@ from typing import List, Optional
 import pandas as pd
 
 
+def validate_and_generate_index(df: pd.DataFrame, time_col: str, frequency: str):
+    """
+    Generate a complete time index for the given DataFrame based on the specified frequency.
+    - Ensures the time column is in datetime format.
+    - Validates consistency in the day of the month if frequency is "MS" (month start).
+    - Generates a new time index from the minimum to the maximum timestamp in the data.
+    :param df: The input DataFrame containing the time column.
+    :param time_col: The name of the time column.
+    :param frequency: The frequency of the time series.
+    :return: A complete time index covering the full range of the dataset.
+    :raises ValueError: If the day-of-month pattern is inconsistent for "MS" frequency.
+    """
+    if frequency.upper() != "MS":
+        return pd.date_range(df[time_col].min(), df[time_col].max(), freq=frequency)
+
+    df[time_col] = pd.to_datetime(df[time_col])  # Ensure datetime format
+
+    # Extract unique days
+    unique_days = df[time_col].dt.day.unique()
+
+    if len(unique_days) == 1:
+        # All dates have the same day-of-month, considered consistent
+        day_of_month = unique_days[0]
+    else:
+        # Check if all dates are last days of their respective months
+        is_last_day = (df[time_col] + pd.offsets.MonthEnd(0)) == df[time_col]
+        if is_last_day.all():
+            day_of_month = "MonthEnd"
+        else:
+            raise ValueError("Inconsistent day of the month found in time column.")
+
+    # Generate new index based on detected pattern
+    total_min, total_max = df[time_col].min(), df[time_col].max()
+    month_starts = pd.date_range(start=total_min.to_period("M").to_timestamp(),
+                                 end=total_max.to_period("M").to_timestamp(),
+                                 freq="MS")
+
+    if day_of_month == "MonthEnd":
+        new_index_full = month_starts + pd.offsets.MonthEnd(0)
+    else:
+        new_index_full = month_starts.map(lambda d: d.replace(day=day_of_month))
+
+    return new_index_full
+
 def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
                                           frequency: str,
                                           id_cols: Optional[List[str]] = None):
@@ -42,7 +86,7 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
         weekday_name = total_min.strftime("%a").upper() # e.g., "FRI"
         frequency = f"W-{weekday_name}"
 
-    new_index_full = pd.date_range(total_min, total_max, freq=frequency)
+    new_index_full = validate_and_generate_index(df=df, time_col=time_col, frequency=frequency)
 
     if id_cols is not None:
         df_dict = {}
@@ -59,4 +103,10 @@ def set_index_and_fill_missing_time_steps(df: pd.DataFrame, time_col: str,
     df = df.set_index(time_col).sort_index()
 
     # Fill in missing time steps between the min and max time steps
-    return df.reindex(new_index_full)
+    df = df.reindex(new_index_full)
+
+    if frequency.upper() == "MS":
+        # Truncate the day of month to avoid issues with pandas frequency check
+        df = df.to_period("M")
+
+    return df

--- a/runtime/databricks/automl_runtime/forecast/model.py
+++ b/runtime/databricks/automl_runtime/forecast/model.py
@@ -57,10 +57,14 @@ def mlflow_forecast_log_model(forecast_model: ForecastModel,
     :param forecast_model: Forecast model wrapper
     :param sample_input: sample input Dataframes for model inference
     """
-    # log the model without signature if infer_signature is failed.
+    # TODO: [ML-46185] we should not be logging without a signature since it cannot be registered to UC then
     try:
         signature = forecast_model.infer_signature(sample_input)
     except Exception: # noqa
         signature = None
-    mlflow.pyfunc.log_model("model", conda_env=forecast_model.model_env,
-                            python_model=forecast_model, signature=signature)
+    mlflow.pyfunc.log_model(
+        artifact_path="model", 
+        conda_env=forecast_model.model_env,
+        python_model=forecast_model,
+        signature=signature
+    )

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -28,13 +28,17 @@ from databricks.automl_runtime.forecast import OFFSET_ALIAS_MAP, DATE_OFFSET_KEY
 from databricks.automl_runtime.forecast.model import ForecastModel, mlflow_forecast_log_model
 from databricks.automl_runtime.forecast.utils import calculate_period_differences, is_frequency_consistency, \
     make_future_dataframe, make_single_future_dataframe
+from databricks.automl_runtime import version
 
+
+ARIMA_ADDITIONAL_PIP_DEPS = [
+    f"pmdarima=={pmdarima.__version__}",
+    f"pandas=={pd.__version__}",
+    f"databricks-automl-runtime=={version.__version__}"
+]
 
 ARIMA_CONDA_ENV = _mlflow_conda_env(
-    additional_pip_deps=[
-        f"pmdarima=={pmdarima.__version__}",
-        f"pandas=={pd.__version__}",
-    ]
+    additional_pip_deps=ARIMA_ADDITIONAL_PIP_DEPS
 )
 
 

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -27,7 +27,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from databricks.automl_runtime.forecast import OFFSET_ALIAS_MAP, DATE_OFFSET_KEYWORD_MAP
 from databricks.automl_runtime.forecast.model import ForecastModel, mlflow_forecast_log_model
 from databricks.automl_runtime.forecast.utils import calculate_period_differences, is_frequency_consistency, \
-    make_future_dataframe, make_single_future_dataframe
+    make_future_dataframe, make_single_future_dataframe, apply_preprocess_func
 from databricks.automl_runtime import version
 
 
@@ -90,9 +90,17 @@ class ArimaModel(AbstractArimaModel):
     ARIMA mlflow model wrapper for univariate forecasting.
     """
 
-    def __init__(self, pickled_model: bytes, horizon: int, frequency_unit: str,
-                 frequency_quantity: int, start_ds: pd.Timestamp, end_ds: pd.Timestamp,
-                 time_col: str, exogenous_cols: Optional[List[str]] = None) -> None:
+    def __init__(self, 
+                 pickled_model: bytes, 
+                 horizon: int, 
+                 frequency_unit: str,
+                 frequency_quantity: int, 
+                 start_ds: pd.Timestamp, 
+                 end_ds: pd.Timestamp,
+                 time_col: str, 
+                 exogenous_cols: Optional[List[str]] = None,
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for ARIMA.
         :param pickled_model: the pickled ARIMA model as a bytes object.
@@ -104,6 +112,8 @@ class ArimaModel(AbstractArimaModel):
         :param time_col: the column name of the time column
         :param exogenous_cols: Optional list of column names of exogenous variables. If provided, these columns are
         used as additional features in arima model.
+        :param split_col: Optional column name of the split column. It is only used for the preprocess_func.
+        :param preprocess_func: Optional function to preprocess the data. If provided, the data will be preprocessed before the model prediction.
         """
         super().__init__()
         self._pickled_model = pickled_model
@@ -114,6 +124,8 @@ class ArimaModel(AbstractArimaModel):
         self._end_ds = pd.to_datetime(end_ds)
         self._time_col = time_col
         self._exogenous_cols = exogenous_cols
+        self._split_col = split_col
+        self._preprocess_func = preprocess_func
 
     def model(self) -> pmdarima.arima.ARIMA:
         """
@@ -126,26 +138,57 @@ class ArimaModel(AbstractArimaModel):
         self,
         horizon: int = None,
         include_history: bool = True,
-        df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+        future_df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """
-        Predict target column for given horizon_timedelta and history data.
+        Predict target column for given horizon and history data.
         :param horizon: int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
-        :param df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
-        :return: A pd.DataFrame with the forecasts and confidence intervals for given horizon_timedelta and history data.
+        :param future_df: A pd.Dataframe containing future time indices and future covariates if covariates are used in training.
+        :return: A pd.DataFrame with the forecasts and confidence intervals for given horizon and history data.
         """
+        if self._preprocess_func and self._split_col:
+            assert future_df is not None, "future_df is required when preprocess_func is provided"
+            future_df = apply_preprocess_func(future_df, self._preprocess_func, self._split_col)
         horizon = horizon or self._horizon
-        X = None
-        if self._exogenous_cols and df is not None:
-            time_col = self._time_col if self._time_col in df.columns else "ds"
-            X = (df[df[time_col] > self._end_ds].set_index(time_col))[self._exogenous_cols]
-        future_pd = self._forecast(horizon, X)
+        future_feature_df = None
+        # TODO: investigate if we can use future_df directly in the forecast function
+        if self._exogenous_cols:
+            future_feature_df = self._get_future_feature_df(future_df)
+        future_pd = self._forecast(horizon, future_feature_df)
         if include_history:
-            in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, X=X)
+            history_feature_df = self._get_history_feature_df(future_df)
+            in_sample_pd = self._predict_in_sample(start_ds=self._start_ds, end_ds=self._end_ds, feature_df=history_feature_df)
             return pd.concat([in_sample_pd, future_pd]).reset_index(drop=True)
         else:
             return future_pd
+
+    def _get_future_feature_df(self, future_df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Get the future feature dataframe.
+        :param future_df: A pd.Dataframe containing future time indices and future covariates if covariates are used in training.
+        :return: A pd.DataFrame with the future covariates, without the time column.
+        """
+        if future_df is not None:
+            time_col = self._time_col if self._time_col in future_df.columns else "ds"
+            future_feature_df = future_df[future_df[time_col] > self._end_ds].set_index(time_col)[self._exogenous_cols]
+            assert future_feature_df.empty == False, "future_feature_df is empty"
+            return future_feature_df
+        else:
+            return None
+    
+    def _get_history_feature_df(self, future_df: pd.DataFrame = None) -> pd.DataFrame:
+        """
+        Get the history feature dataframe.
+        :param future_df: A pd.Dataframe containing future time indices and future covariates if covariates are used in training.
+        :return: A pd.DataFrame with the history covariates, without the time column.
+        """
+        if future_df is not None:
+            history_feature_df = future_df[future_df[self._time_col] <= self._end_ds].set_index(self._time_col)[self._exogenous_cols]
+            assert history_feature_df.empty == False, "history_feature_df is empty"
+            return history_feature_df
+        else:
+            return None
 
     def make_future_dataframe(self, horizon: int = None, include_history: bool = True) -> pd.DataFrame:
         """
@@ -178,7 +221,10 @@ class ArimaModel(AbstractArimaModel):
         :return: A pd.Series with the prediction values.
         """
         self._validate_cols(model_input, [self._time_col])
-        result_df = self._predict_impl(model_input)
+        test_df = model_input.copy()
+        if self._preprocess_func and self._split_col:
+            test_df = apply_preprocess_func(test_df, self._preprocess_func, self._split_col)
+        result_df = self._predict_impl(test_df)
         return result_df["yhat"]
 
     def _predict_impl(self, input_df: pd.DataFrame) -> pd.DataFrame:
@@ -209,18 +255,18 @@ class ArimaModel(AbstractArimaModel):
         # Out-of-sample prediction if needed
         horizon = calculate_period_differences(self._end_ds, max(df["ds"]), self._frequency_unit, self._frequency_quantity)
         if horizon > 0:
-            X_future = df[df["ds"] > self._end_ds].set_index("ds")
+            future_feature_df = df[df["ds"] > self._end_ds].set_index("ds")
             future_pd = self._forecast(
                 horizon,
-                X=X_future[self._exogenous_cols] if self._exogenous_cols else None)
+                feature_df=future_feature_df[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(future_pd)
         # In-sample prediction if needed
         if pred_start_ds <= self._end_ds:
-            X_in_sample = df[df["ds"] <= self._end_ds].set_index("ds")
+            df_in_sample = df[df["ds"] <= self._end_ds].set_index("ds")
             in_sample_pd = self._predict_in_sample(
                 start_ds=pred_start_ds,
                 end_ds=self._end_ds,
-                X=X_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
+                feature_df=df_in_sample[self._exogenous_cols] if self._exogenous_cols else None)
             preds_pds.append(in_sample_pd)
         # Map predictions back to given timestamps
         preds_pd = pd.concat(preds_pds).set_index("ds")
@@ -231,7 +277,7 @@ class ArimaModel(AbstractArimaModel):
         self,
         start_ds: pd.Timestamp = None,
         end_ds: pd.Timestamp = None,
-        X: pd.DataFrame = None) -> pd.DataFrame:
+        feature_df: pd.DataFrame = None) -> pd.DataFrame:
         if start_ds and end_ds:
             start_idx = calculate_period_differences(self._start_ds, start_ds, self._frequency_unit, self._frequency_quantity)
             end_idx = calculate_period_differences(self._start_ds, end_ds, self._frequency_unit, self._frequency_quantity)
@@ -242,7 +288,7 @@ class ArimaModel(AbstractArimaModel):
         d = self.model().order[1]
         start_idx = max(start_idx, d)
         preds_in_sample, conf_in_sample = self.model().predict_in_sample(
-            X=X,
+            X=feature_df,
             start=start_idx,
             end=end_idx,
             return_conf_int=True)
@@ -255,11 +301,22 @@ class ArimaModel(AbstractArimaModel):
     def _forecast(
         self,
         horizon: int = None,
-        X: pd.DataFrame = None) -> pd.DataFrame:
-        horizon = horizon or self._horizon
+        feature_df: pd.DataFrame = None) -> pd.DataFrame:
+        """
+        Do forecast for future data. feature_df should only contain future covariates, without the time column.
+        Unlike Prophet, pmdarima does not require time column in the feature_df, it depends on horizon to determine the length of the prediction
+        :param horizon: int number of periods to forecast forward.
+        :param feature_df: A pd.Dataframe with the future covariates, without the time column.
+        :return: A pd.DataFrame with the forecasts.
+        """
+        # set horizon to the length of future_df if future_df is provided to avoid the length mismatch error from pmdarima
+        if feature_df is None:
+            horizon = horizon or self._horizon
+        else:
+            horizon = len(feature_df)
         preds, conf = self.model().predict(
             horizon,
-            X=X,
+            X=feature_df,
             return_conf_int=True)
         ds_indices = self._get_ds_indices(start_ds=self._end_ds, periods=horizon + 1, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[1:]
         preds_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds})
@@ -272,9 +329,18 @@ class MultiSeriesArimaModel(AbstractArimaModel):
     ARIMA mlflow model wrapper for multivariate forecasting.
     """
 
-    def __init__(self, pickled_model_dict: Dict[Tuple, bytes], horizon: int, frequency_unit: str, frequency_quantity: int,
-                 start_ds_dict: Dict[Tuple, pd.Timestamp], end_ds_dict: Dict[Tuple, pd.Timestamp],
-                 time_col: str, id_cols: List[str], exogenous_cols: Optional[List[str]] = None) -> None:
+    def __init__(self, 
+                 pickled_model_dict: Dict[Tuple, bytes], 
+                 horizon: int, 
+                 frequency_unit: str, 
+                 frequency_quantity: int,
+                 start_ds_dict: Dict[Tuple, pd.Timestamp], 
+                 end_ds_dict: Dict[Tuple, pd.Timestamp],
+                 time_col: str, 
+                 id_cols: List[str], 
+                 exogenous_cols: Optional[List[str]] = None,
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for multiseries ARIMA.
         :param pickled_model_dict: the dictionary of binarized ARIMA models for different time series.
@@ -287,6 +353,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         :param id_cols: the column names of the identity columns for multi-series time series
         :param exogenous_cols: Optional list of column names of exogenous variables. If provided, these columns are
         used as additional features in arima model.
+        :param split_col: Optional column name of the split column. It is only used for the preprocess_func.
+        :param preprocess_func: Optional function to preprocess the data. If provided, the data will be preprocessed before the model prediction.
         """
         super().__init__()
         self._pickled_models = pickled_model_dict
@@ -298,6 +366,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         self._time_col = time_col
         self._id_cols = id_cols
         self._exogenous_cols = exogenous_cols
+        self._split_col = split_col
+        self._preprocess_func = preprocess_func
 
     def model(self, id_: Tuple) -> pmdarima.arima.ARIMA:
         """
@@ -347,18 +417,21 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         self,
         horizon: int = None,
         include_history: bool = True,
-        df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+        future_df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         """
-        Predict target column for given horizon_timedelta and history data.
+        Predict target column for given horizon and history data.
         :param horizon: Int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
-        :param df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
+        :param future_df: A pd.Dataframe containing regressors (exogenous variables), if they were used to train the model.
         :return: A pd.DataFrame with the forecast components.
         """
         horizon = horizon or self._horizon
         ids = self._pickled_models.keys()
-        preds_dfs = list(map(lambda id_: self._predict_timeseries_single_id(id_, horizon, include_history, df), ids))
+        if future_df is not None:
+            # Add ts_id column to future_df because preprocess_func requires it
+            future_df["ts_id"] = future_df[self._id_cols].apply(tuple, axis=1)
+        preds_dfs = list(map(lambda id_: self._predict_timeseries_single_id(id_, horizon, include_history, future_df), ids))
         return pd.concat(preds_dfs).reset_index(drop=True)
 
     def _predict_timeseries_single_id(
@@ -368,7 +441,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         include_history: bool = True,
         df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
         arima_model_single_id = ArimaModel(self._pickled_models[id_], self._horizon, self._frequency_unit, self._frequency_quantity,
-                                           self._starts[id_], self._ends[id_], self._time_col, self._exogenous_cols)
+                                           self._starts[id_], self._ends[id_], self._time_col, self._exogenous_cols, self._split_col, self._preprocess_func)
         preds_df = arima_model_single_id.predict_timeseries(horizon, include_history, df)
         for id, col_name in zip(id_, self._id_cols):
             preds_df[col_name] = id
@@ -400,6 +473,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if self._preprocess_func and self._split_col:
+            df = apply_preprocess_func(df, self._preprocess_func, self._split_col)
         preds_df = df.groupby(self._id_cols).apply(self._predict_single_id).reset_index(drop=True)
         df = df.merge(preds_df, how="left", on=[self._time_col] + self._id_cols)  # merge predictions to original order
         return df["yhat"]
@@ -413,7 +488,9 @@ class MultiSeriesArimaModel(AbstractArimaModel):
                                            self._starts[id_],
                                            self._ends[id_],
                                            self._time_col,
-                                           self._exogenous_cols)
+                                           self._exogenous_cols,
+                                           self._split_col,
+                                           self._preprocess_func)
         df["yhat"] = arima_model_single_id.predict(context=None, model_input=df).to_list()
         return df
 

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -64,18 +64,19 @@ class AbstractArimaModel(ForecastModel):
         return ARIMA_CONDA_ENV
 
     @staticmethod
-    def _get_ds_indices(start_ds: pd.Timestamp, periods: int, frequency: str) -> pd.DatetimeIndex:
+    def _get_ds_indices(start_ds: pd.Timestamp, periods: int, frequency_unit: str, frequency_quantity: int) -> pd.DatetimeIndex:
         """
         Create a DatetimeIndex with specified starting time and frequency, whose length is the given periods.
         :param start_ds: the pd.Timestamp as the start of the DatetimeIndex.
         :param periods: the length of the DatetimeIndex.
-        :param frequency: the frequency of the DatetimeIndex.
+        :param frequency_unit: the frequency unit of the DatetimeIndex.
+        :param frequency_quantity: the frequency quantity of the DatetimeIndex.
         :return: a DatetimeIndex.
         """
         ds_indices = pd.date_range(
             start=start_ds,
             periods=periods,
-            freq=pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency])
+            freq=pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit]) * frequency_quantity
         )
         modified_start_ds = ds_indices.min()
         if start_ds != modified_start_ds:
@@ -89,14 +90,15 @@ class ArimaModel(AbstractArimaModel):
     ARIMA mlflow model wrapper for univariate forecasting.
     """
 
-    def __init__(self, pickled_model: bytes, horizon: int, frequency: str,
-                 start_ds: pd.Timestamp, end_ds: pd.Timestamp,
+    def __init__(self, pickled_model: bytes, horizon: int, frequency_unit: str,
+                 frequency_quantity: int, start_ds: pd.Timestamp, end_ds: pd.Timestamp,
                  time_col: str, exogenous_cols: Optional[List[str]] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for ARIMA.
         :param pickled_model: the pickled ARIMA model as a bytes object.
         :param horizon: int number of periods to forecast forward.
-        :param frequency: the frequency of the time series
+        :param frequency_unit: the frequency unit of the time series
+        :param frequency_quantity: the frequency quantity of the time series
         :param start_ds: the start time of training data
         :param end_ds: the end time of training data
         :param time_col: the column name of the time column
@@ -106,7 +108,8 @@ class ArimaModel(AbstractArimaModel):
         super().__init__()
         self._pickled_model = pickled_model
         self._horizon = horizon
-        self._frequency = OFFSET_ALIAS_MAP[frequency]
+        self._frequency_unit = OFFSET_ALIAS_MAP[frequency_unit]
+        self._frequency_quantity = frequency_quantity
         self._start_ds = pd.to_datetime(start_ds)
         self._end_ds = pd.to_datetime(end_ds)
         self._time_col = time_col
@@ -157,7 +160,8 @@ class ArimaModel(AbstractArimaModel):
             start_time=self._start_ds,
             end_time=self._end_ds,
             horizon=horizon or self._horizon,
-            frequency=self._frequency,
+            frequency_unit=self._frequency_unit,
+            frequency_quantity=self._frequency_quantity,
             include_history=include_history
         )
 
@@ -192,7 +196,7 @@ class ArimaModel(AbstractArimaModel):
             )
         # Check if the time has correct frequency
         consistency = df["ds"].apply(lambda x: 
-            is_frequency_consistency(self._start_ds, x, self._frequency)
+            is_frequency_consistency(self._start_ds, x, self._frequency_unit, self._frequency_quantity)
         ).all()
         if not consistency:
             raise MlflowException(
@@ -203,7 +207,7 @@ class ArimaModel(AbstractArimaModel):
             )
         preds_pds = []
         # Out-of-sample prediction if needed
-        horizon = calculate_period_differences(self._end_ds, max(df["ds"]), self._frequency)
+        horizon = calculate_period_differences(self._end_ds, max(df["ds"]), self._frequency_unit, self._frequency_quantity)
         if horizon > 0:
             X_future = df[df["ds"] > self._end_ds].set_index("ds")
             future_pd = self._forecast(
@@ -229,8 +233,8 @@ class ArimaModel(AbstractArimaModel):
         end_ds: pd.Timestamp = None,
         X: pd.DataFrame = None) -> pd.DataFrame:
         if start_ds and end_ds:
-            start_idx = calculate_period_differences(self._start_ds, start_ds, self._frequency)
-            end_idx = calculate_period_differences(self._start_ds, end_ds, self._frequency)
+            start_idx = calculate_period_differences(self._start_ds, start_ds, self._frequency_unit, self._frequency_quantity)
+            end_idx = calculate_period_differences(self._start_ds, end_ds, self._frequency_unit, self._frequency_quantity)
         else:
             start_ds = self._start_ds
             end_ds = self._end_ds
@@ -242,8 +246,8 @@ class ArimaModel(AbstractArimaModel):
             start=start_idx,
             end=end_idx,
             return_conf_int=True)
-        periods = calculate_period_differences(self._start_ds, end_ds, self._frequency) + 1
-        ds_indices = self._get_ds_indices(start_ds=self._start_ds, periods=periods, frequency=self._frequency)[start_idx:]
+        periods = calculate_period_differences(self._start_ds, end_ds, self._frequency_unit, self._frequency_quantity) + 1
+        ds_indices = self._get_ds_indices(start_ds=self._start_ds, periods=periods, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[start_idx:]
         in_sample_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds_in_sample})
         in_sample_pd[["yhat_lower", "yhat_upper"]] = conf_in_sample
         return in_sample_pd
@@ -257,7 +261,7 @@ class ArimaModel(AbstractArimaModel):
             horizon,
             X=X,
             return_conf_int=True)
-        ds_indices = self._get_ds_indices(start_ds=self._end_ds, periods=horizon + 1, frequency=self._frequency)[1:]
+        ds_indices = self._get_ds_indices(start_ds=self._end_ds, periods=horizon + 1, frequency_unit=self._frequency_unit, frequency_quantity=self._frequency_quantity)[1:]
         preds_pd = pd.DataFrame({'ds': ds_indices, 'yhat': preds})
         preds_pd[["yhat_lower", "yhat_upper"]] = conf
         return preds_pd
@@ -268,14 +272,15 @@ class MultiSeriesArimaModel(AbstractArimaModel):
     ARIMA mlflow model wrapper for multivariate forecasting.
     """
 
-    def __init__(self, pickled_model_dict: Dict[Tuple, bytes], horizon: int, frequency: str,
+    def __init__(self, pickled_model_dict: Dict[Tuple, bytes], horizon: int, frequency_unit: str, frequency_quantity: int,
                  start_ds_dict: Dict[Tuple, pd.Timestamp], end_ds_dict: Dict[Tuple, pd.Timestamp],
                  time_col: str, id_cols: List[str], exogenous_cols: Optional[List[str]] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for multiseries ARIMA.
         :param pickled_model_dict: the dictionary of binarized ARIMA models for different time series.
         :param horizon: int number of periods to forecast forward.
-        :param frequency: the frequency of the time series
+        :param frequency_unit: the frequency unit of the time series
+        :param frequency_quantity: the frequency quantity of the time series
         :param start_ds_dict: the dictionary of the starting time of each time series in training data.
         :param end_ds_dict: the dictionary of the end time of each time series in training data.
         :param time_col: the column name of the time column
@@ -286,7 +291,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         super().__init__()
         self._pickled_models = pickled_model_dict
         self._horizon = horizon
-        self._frequency = frequency
+        self._frequency_unit = frequency_unit
+        self._frequency_quantity = frequency_quantity
         self._starts = start_ds_dict
         self._ends = end_ds_dict
         self._time_col = time_col
@@ -329,7 +335,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
             start_time=self._starts,
             end_time=self._ends,
             horizon=horizon,
-            frequency=self._frequency,
+            frequency_unit=self._frequency_unit,
+            frequency_quantity=self._frequency_quantity,
             include_history=include_history,
             groups=groups,
             identity_column_names=self._id_cols
@@ -360,7 +367,7 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         horizon: int,
         include_history: bool = True,
         df: Optional[pd.DataFrame] = None) -> pd.DataFrame:
-        arima_model_single_id = ArimaModel(self._pickled_models[id_], self._horizon, self._frequency,
+        arima_model_single_id = ArimaModel(self._pickled_models[id_], self._horizon, self._frequency_unit, self._frequency_quantity,
                                            self._starts[id_], self._ends[id_], self._time_col, self._exogenous_cols)
         preds_df = arima_model_single_id.predict_timeseries(horizon, include_history, df)
         for id, col_name in zip(id_, self._id_cols):
@@ -401,7 +408,8 @@ class MultiSeriesArimaModel(AbstractArimaModel):
         id_ = df["ts_id"].to_list()[0]
         arima_model_single_id = ArimaModel(self._pickled_models[id_],
                                            self._horizon,
-                                           self._frequency,
+                                           self._frequency_unit,
+                                           self._frequency_quantity,
                                            self._starts[id_],
                                            self._ends[id_],
                                            self._time_col,

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/model.py
@@ -17,6 +17,7 @@ import pickle
 from abc import abstractmethod
 from typing import List, Dict, Tuple, Optional, Union
 
+import category_encoders
 import pandas as pd
 import mlflow
 import pmdarima
@@ -34,6 +35,7 @@ from databricks.automl_runtime import version
 ARIMA_ADDITIONAL_PIP_DEPS = [
     f"pmdarima=={pmdarima.__version__}",
     f"pandas=={pd.__version__}",
+    f"category_encoders=={category_encoders.__version__}",
     f"databricks-automl-runtime=={version.__version__}"
 ]
 

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -35,7 +35,8 @@ class ArimaEstimator:
     """
 
     def __init__(self, horizon: int, frequency_unit: str, metric: str, seasonal_periods: List[int],
-                 num_folds: int = 20, max_steps: int = 150, exogenous_cols: Optional[List[str]] = None) -> None:
+                 num_folds: int = 20, max_steps: int = 150, exogenous_cols: Optional[List[str]] = None,
+                 split_cutoff: Optional[pd.Timestamp] = None) -> None:
         """
         :param horizon: Number of periods to forecast forward
         :param frequency_unit: Frequency of the time series
@@ -45,6 +46,10 @@ class ArimaEstimator:
         :param max_steps: Max steps for stepwise auto_arima
         :param exogenous_cols: Optional list of column names of exogenous variables. If provided, these columns are
         used as additional features in arima model.
+        :param split_cutoff: Optional cutoff specified by user. If provided, 
+        it is the starting point of cutoffs for cross validation.
+        For tuning job, it is the cutoff between train and validate split.
+        For training job, it is the cutoff bewteen validate and test split.
         """
         self._horizon = horizon
         self._frequency_unit = OFFSET_ALIAS_MAP[frequency_unit]
@@ -53,6 +58,7 @@ class ArimaEstimator:
         self._num_folds = num_folds
         self._max_steps = max_steps
         self._exogenous_cols = exogenous_cols
+        self._split_cutoff = split_cutoff
 
     def fit(self, df: pd.DataFrame) -> pd.DataFrame:
         """
@@ -88,12 +94,20 @@ class ArimaEstimator:
                 # so the minimum valid seasonality period is always 1
 
                 validation_horizon = utils.get_validation_horizon(history_pd, self._horizon, self._frequency_unit)
-                cutoffs = utils.generate_cutoffs(
-                    history_pd,
-                    horizon=validation_horizon,
-                    unit=self._frequency_unit,
-                    num_folds=self._num_folds,
-                )
+                if self._split_cutoff:
+                    cutoffs = utils.generate_custom_cutoffs(
+                        history_pd,
+                        horizon=validation_horizon,
+                        unit=self._frequency_unit,
+                        split_cutoff=self._split_cutoff
+                    )
+                else:
+                    cutoffs = utils.generate_cutoffs(
+                        history_pd,
+                        horizon=validation_horizon,
+                        unit=self._frequency_unit,
+                        num_folds=self._num_folds,
+                    )
 
                 result = self._fit_predict(history_pd, cutoffs=cutoffs, seasonal_period=m, max_steps=self._max_steps)
                 metric = result["metrics"]["smape"]

--- a/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
+++ b/runtime/databricks/automl_runtime/forecast/pmdarima/training.py
@@ -36,7 +36,7 @@ class ArimaEstimator:
 
     def __init__(self, horizon: int, frequency_unit: str, metric: str, seasonal_periods: List[int],
                  num_folds: int = 20, max_steps: int = 150, exogenous_cols: Optional[List[str]] = None,
-                 split_cutoff: Optional[pd.Timestamp] = None) -> None:
+                 split_cutoff: Optional[pd.Timestamp] = None, frequency_quantity: int = 1) -> None:
         """
         :param horizon: Number of periods to forecast forward
         :param frequency_unit: Frequency of the time series
@@ -47,12 +47,14 @@ class ArimaEstimator:
         :param exogenous_cols: Optional list of column names of exogenous variables. If provided, these columns are
         used as additional features in arima model.
         :param split_cutoff: Optional cutoff specified by user. If provided, 
+        :param frequency_quantity: The number of frequency units in the frequency. Default is 1.
         it is the starting point of cutoffs for cross validation.
         For tuning job, it is the cutoff between train and validate split.
         For training job, it is the cutoff bewteen validate and test split.
         """
         self._horizon = horizon
         self._frequency_unit = OFFSET_ALIAS_MAP[frequency_unit]
+        self._frequency_quantity = frequency_quantity
         self._metric = metric
         self._seasonal_periods = seasonal_periods
         self._num_folds = num_folds
@@ -70,14 +72,14 @@ class ArimaEstimator:
         history_pd["ds"] = pd.to_datetime(history_pd["ds"])
 
         # Check if the time has consistent frequency
-        self._validate_ds_freq(history_pd, self._frequency_unit)
+        self._validate_ds_freq(history_pd, self._frequency_unit, self._frequency_quantity)
 
         history_periods = utils.calculate_period_differences(
-            history_pd['ds'].min(), history_pd['ds'].max(), self._frequency_unit
+            history_pd['ds'].min(), history_pd['ds'].max(), self._frequency_unit, self._frequency_quantity
         )
         if history_periods + 1 != history_pd['ds'].size:
             # Impute missing time steps
-            history_pd = self._fill_missing_time_steps(history_pd, self._frequency_unit)
+            history_pd = self._fill_missing_time_steps(history_pd, self._frequency_unit, self._frequency_quantity)
 
 
         # Tune seasonal periods
@@ -87,26 +89,28 @@ class ArimaEstimator:
             try:
                 # this check mirrors the the default behavior by prophet
                 if history_periods < 2 * m:
-                    _logger.warning(f"Skipping seasonal_period={m} ({self._frequency_unit}). Dataframe timestamps must span at least two seasonality periods, but only spans {history_periods} {self._frequency_unit}""")
+                    _logger.warning(f"Skipping seasonal_period={m} ({self._frequency_quantity}{self._frequency_unit}). Dataframe timestamps must span at least two seasonality periods, but only spans {history_periods} {self._frequency_quantity}{self._frequency_unit}""")
                     continue
                 # Prophet also rejects the seasonality periods if the seasonality period timedelta is less than the shortest timedelta in the dataframe.
                 # However, this cannot happen in ARIMA because _fill_missing_time_steps imputes values for each _frequency_unit,
                 # so the minimum valid seasonality period is always 1
 
-                validation_horizon = utils.get_validation_horizon(history_pd, self._horizon, self._frequency_unit)
+                validation_horizon = utils.get_validation_horizon(history_pd, self._horizon, self._frequency_unit, self._frequency_quantity)
                 if self._split_cutoff:
                     cutoffs = utils.generate_custom_cutoffs(
                         history_pd,
                         horizon=validation_horizon,
-                        unit=self._frequency_unit,
-                        split_cutoff=self._split_cutoff
+                        frequency_unit=self._frequency_unit,
+                        split_cutoff=self._split_cutoff,
+                        frequency_quantity=self._frequency_quantity,
                     )
                 else:
                     cutoffs = utils.generate_cutoffs(
                         history_pd,
                         horizon=validation_horizon,
-                        unit=self._frequency_unit,
+                        frequency_unit=self._frequency_unit,
                         num_folds=self._num_folds,
+                        frequency_quantity=self._frequency_quantity,
                     )
 
                 result = self._fit_predict(history_pd, cutoffs=cutoffs, seasonal_period=m, max_steps=self._max_steps)
@@ -150,9 +154,9 @@ class ArimaEstimator:
         return {"metrics": metrics, "model": arima_model}
 
     @staticmethod
-    def _fill_missing_time_steps(df: pd.DataFrame, frequency: str):
+    def _fill_missing_time_steps(df: pd.DataFrame, frequency_unit: str, frequency_quantity: int):
         # Forward fill missing time steps
-        df_filled = df.set_index("ds").resample(rule=OFFSET_ALIAS_MAP[frequency]).pad().reset_index()
+        df_filled = df.set_index("ds").resample(rule=f"{frequency_quantity}{OFFSET_ALIAS_MAP[frequency_unit]}").pad().reset_index()
         start_ds, modified_start_ds = df["ds"].min(), df_filled["ds"].min()
         if start_ds != modified_start_ds:
             offset = modified_start_ds - start_ds
@@ -160,12 +164,12 @@ class ArimaEstimator:
         return df_filled
 
     @staticmethod
-    def _validate_ds_freq(df: pd.DataFrame, frequency: str):
+    def _validate_ds_freq(df: pd.DataFrame, frequency_unit: str, frequency_quantity: int):
         start_ds = df["ds"].min()
         consistency = df["ds"].apply(lambda x:
-            utils.is_frequency_consistency(start_ds, x, frequency)
+            utils.is_frequency_consistency(start_ds, x, frequency_unit, frequency_quantity)
         ).all()
         if not consistency:
             raise ValueError(
-                f"Input time column includes different frequency than the specified frequency {frequency}."
+                f"Input time column includes different frequency than the specified frequency {frequency_quantity}{frequency_unit}."
             )

--- a/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/forecast.py
@@ -38,10 +38,12 @@ class ProphetHyperParams(Enum):
 
 
 def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
-                         horizon: int, frequency: str, cutoffs: List[pd.Timestamp],
+                         horizon: int, frequency_unit: str, cutoffs: List[pd.Timestamp],
                          interval_width: int, primary_metric: str,
                          country_holidays: Optional[str] = None,
-                         regressors = None, **prophet_kwargs) -> Dict[str, Any]:
+                         regressors = None, 
+                         frequency_quantity: int = 1,
+                         **prophet_kwargs) -> Dict[str, Any]:
     """
     Training function for hyperparameter tuning with hyperopt
 
@@ -49,7 +51,8 @@ def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
     :param history_pd: pd.DataFrame containing the history. Must have columns ds (date
             type) and y, the time series
     :param horizon: Forecast horizon_timedelta
-    :param frequency: Frequency of the time series
+    :param frequency_unit: Frequency unit of the time series
+    :param frequency_quantity: the number of time units that make up a single period of the time series. For now, only 1/5/10/15/30 minutes, 1 hour, 1 day, 1 week, 1 month, 1 quarter, 1 year are supported.
     :param num_folds: Number of folds for cross validation
     :param interval_width: Width of the uncertainty intervals provided for the forecast
     :param primary_metric: Metric that will be optimized across trials
@@ -67,8 +70,8 @@ def _prophet_fit_predict(params: Dict[str, Any], history_pd: pd.DataFrame,
             model.add_regressor(regressor)
 
     model.fit(history_pd, iter=200)
-    offset_kwarg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[frequency]]
-    horizon_offset = pd.DateOffset(**offset_kwarg)*horizon
+    offset_kwarg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[frequency_unit]]
+    horizon_offset = pd.DateOffset(**offset_kwarg)*frequency_quantity*horizon
     # Evaluate Metrics
     df_cv = cross_validation(
         model, horizon=horizon_offset, cutoffs=cutoffs, disable_tqdm=True
@@ -92,7 +95,9 @@ class ProphetHyperoptEstimator(ABC):
                  max_eval: int = 10, trial_timeout: int = None,
                  random_state: int = 0, is_parallel: bool = True,
                  regressors = None, 
-                 split_cutoff: Optional[pd.Timestamp] = None, **prophet_kwargs) -> None:
+                 split_cutoff: Optional[pd.Timestamp] = None, 
+                 frequency_quantity: int = 1,
+                 **prophet_kwargs) -> None:
         """
         Initialization
 
@@ -119,6 +124,7 @@ class ProphetHyperoptEstimator(ABC):
         """
         self._horizon = horizon
         self._frequency_unit = OFFSET_ALIAS_MAP[frequency_unit]
+        self._frequency_quantity = frequency_quantity
         self._metric = metric
         self._interval_width = interval_width
         self._country_holidays = country_holidays
@@ -144,24 +150,28 @@ class ProphetHyperoptEstimator(ABC):
 
         seasonality_mode = ["additive", "multiplicative"]
 
-        validation_horizon = utils.get_validation_horizon(df, self._horizon, self._frequency_unit)
+        validation_horizon = utils.get_validation_horizon(df, self._horizon, self._frequency_unit, self._frequency_quantity)
         if self._split_cutoff:
             cutoffs = utils.generate_custom_cutoffs(
                 df.reset_index(drop=True),
                 horizon=validation_horizon,
-                unit=self._frequency_unit,
-                split_cutoff=self._split_cutoff
+                frequency_unit=self._frequency_unit,
+                split_cutoff=self._split_cutoff,
+                frequency_quantity=self._frequency_quantity,
             )
         else:
             cutoffs = utils.generate_cutoffs(
                 df.reset_index(drop=True),
                 horizon=validation_horizon,
-                unit=self._frequency_unit,
+                frequency_unit=self._frequency_unit,
                 num_folds=self._num_folds,
+                frequency_quantity=self._frequency_quantity,
             )
 
         train_fn = partial(_prophet_fit_predict, history_pd=df, horizon=validation_horizon,
-                           frequency=self._frequency_unit, cutoffs=cutoffs,
+                           frequency_unit=self._frequency_unit, 
+                           frequency_quantity=self._frequency_quantity,
+                           cutoffs=cutoffs,
                            interval_width=self._interval_width,
                            primary_metric=self._metric, country_holidays=self._country_holidays,
                            regressors=self._regressors, **self._prophet_kwargs)

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -29,12 +29,14 @@ from databricks.automl_runtime import version
 from databricks.automl_runtime.forecast.utils import is_quaterly_alias, make_future_dataframe
 
 
-PROPHET_CONDA_ENV = _mlflow_conda_env(
-    additional_pip_deps=[
+PROPHET_ADDITIONAL_PIP_DEPS = [
         f"prophet=={prophet.__version__}",
         f"cloudpickle=={cloudpickle.__version__}",
         f"databricks-automl-runtime=={version.__version__}",
     ]
+
+PROPHET_CONDA_ENV = _mlflow_conda_env(
+    additional_pip_deps=PROPHET_ADDITIONAL_PIP_DEPS
 )
 
 

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -50,7 +50,9 @@ class ProphetModel(ForecastModel):
                  horizon: int, 
                  frequency_unit: str, 
                  frequency_quantity: int,
-                 time_col: str) -> None:
+                 time_col: str,
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for mlflow
         :param model_json: json string of the Prophet model or
@@ -59,6 +61,8 @@ class ProphetModel(ForecastModel):
         :param frequency_unit: the frequency unit of the time series
         :param frequency_quantity: the frequency quantity of the time series
         :param time_col: the column name of the time column
+        :param split_col: Optional column name of the split columns
+        :param preprocess_func: Optional callable function for preprocessing input data
         """
         self._model_json = model_json
         self._horizon = horizon
@@ -66,6 +70,8 @@ class ProphetModel(ForecastModel):
         self._frequency_quantity = frequency_quantity
         self._time_col = time_col
         self._is_quaterly = is_quaterly_alias(frequency_unit)
+        self._split_col = split_col
+        self._preprocess_func = preprocess_func
         super().__init__()
 
     def load_context(self, context: mlflow.pyfunc.model.PythonModelContext) -> None:
@@ -134,7 +140,20 @@ class ProphetModel(ForecastModel):
         :return: A pd.DataFrame with the forecast components.
         """
         self._validate_cols(model_input, [self._time_col])
-        test_df = pd.DataFrame({"ds": model_input[self._time_col]})
+        test_df = model_input.copy()
+
+        if self._preprocess_func and self._split_col:
+            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            test_df["y"] = None
+            test_df[self._split_col] = "prediction"
+            test_df = self._preprocess_func(test_df)
+            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+
+        test_df.rename(columns={self._time_col: "ds"}, inplace=True)
         predict_df = self.model().predict(test_df)
         return predict_df["yhat"]
 
@@ -150,9 +169,17 @@ class MultiSeriesProphetModel(ProphetModel):
     Prophet mlflow model wrapper for multi-series forecasting.
     """
 
-    def __init__(self, model_json: Dict[Tuple, str], timeseries_starts: Dict[Tuple, pd.Timestamp],
-                 timeseries_end: str, horizon: int, frequency_unit: str, frequency_quantity: int, time_col: str, id_cols: List[str],
-                 ) -> None:
+    def __init__(self, 
+                 model_json: Dict[Tuple, str], 
+                 timeseries_starts: Dict[Tuple, pd.Timestamp],
+                 timeseries_end: str, 
+                 horizon: int, 
+                 frequency_unit: str, 
+                 frequency_quantity: int, 
+                 time_col: str, 
+                 id_cols: List[str],
+                 split_col: Optional[str] = None,
+                 preprocess_func: Optional[callable] = None) -> None:
         """
         Initialize the mlflow Python model wrapper for mlflow
         :param model_json: the dictionary of json strings of Prophet model for multi-series forecasting
@@ -163,8 +190,10 @@ class MultiSeriesProphetModel(ProphetModel):
         :param frequency_quantity: the frequency quantity of the time series
         :param time_col: the column name of the time column
         :param id_cols: the column names of the identity columns for multi-series time series
+        :param split_col: Optional column name of the split columns
+        :param preprocess_func: Optional callable function for preprocessing input data
         """
-        super().__init__(model_json, horizon, frequency_unit, frequency_quantity, time_col)
+        super().__init__(model_json, horizon, frequency_unit, frequency_quantity, time_col, split_col, preprocess_func)
         self._frequency_unit = frequency_unit
         self._frequency_quantity = frequency_quantity
         self._timeseries_end = timeseries_end
@@ -297,6 +326,18 @@ class MultiSeriesProphetModel(ProphetModel):
         self._validate_cols(model_input, self._id_cols + [self._time_col])
         test_df = model_input.copy()
         test_df["ts_id"] = test_df[self._id_cols].apply(tuple, axis=1)
+
+        if self._preprocess_func and self._split_col:
+            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
+            # and the split column to be present, as they are used in the trial notebook. These columns are added 
+            # temporarily and removed after preprocessing.
+            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+            test_df["y"] = None
+            test_df[self._split_col] = ""
+            test_df = test_df.groupby(self._id_cols).apply(self._preprocess_func).reset_index(drop=True)
+            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+
         test_df.rename(columns={self._time_col: "ds"}, inplace=True)
 
         def model_prediction(df):

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -19,6 +19,7 @@ import cloudpickle
 import mlflow
 import pandas as pd
 import prophet
+import category_encoders
 
 from mlflow.models.signature import ModelSignature
 from mlflow.utils.environment import _mlflow_conda_env
@@ -32,6 +33,7 @@ from databricks.automl_runtime.forecast.utils import is_quaterly_alias, make_fut
 PROPHET_ADDITIONAL_PIP_DEPS = [
         f"prophet=={prophet.__version__}",
         f"cloudpickle=={cloudpickle.__version__}",
+        f"category_encoders=={category_encoders.__version__}",
         f"databricks-automl-runtime=={version.__version__}",
     ]
 

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -26,7 +26,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from databricks.automl_runtime.forecast import OFFSET_ALIAS_MAP, DATE_OFFSET_KEYWORD_MAP
 from databricks.automl_runtime.forecast.model import ForecastModel, mlflow_forecast_log_model
 from databricks.automl_runtime import version
-from databricks.automl_runtime.forecast.utils import is_quaterly_alias, make_future_dataframe
+from databricks.automl_runtime.forecast.utils import is_quaterly_alias, make_future_dataframe, apply_preprocess_func
 
 
 PROPHET_ADDITIONAL_PIP_DEPS = [
@@ -110,26 +110,36 @@ class ProphetModel(ForecastModel):
                                                   freq=pd.DateOffset(**offset_kwarg),
                                                   include_history=include_history)
 
-    def _predict_impl(self, horizon: int = None, include_history: bool = True) -> pd.DataFrame:
+    def _predict_impl(self, future_df: pd.DataFrame) -> pd.DataFrame:
         """
         Predict using the API from prophet model.
-        :param horizon: Int number of periods to forecast forward.
-        :param include_history: Boolean to include the historical dates in the data
-            frame for predictions.
-        :return: A pd.DataFrame with the forecast components.
+        :param future_df: future input dataframe. This dataframe should contain 
+            the time series column and covariate columns if available. It is used as the 
+            input for generating predictions.
+        :return: A pd.DataFrame that represents the model's output. The predicted target 
+            column is named 'yhat'.
         """
-        future_pd = self.make_future_dataframe(horizon=horizon or self._horizon, include_history=include_history)
-        return self.model().predict(future_pd)
+        return self.model().predict(future_df)
 
-    def predict_timeseries(self, horizon: int = None, include_history: bool = True) -> pd.DataFrame:
+    def predict_timeseries(self, horizon: int = None, include_history: bool = True, future_df: pd.DataFrame = None) -> pd.DataFrame:
         """
-        Predict using the prophet model.
+        Predict using the prophet model. The input dataframe will be preprocessed if with covariates.
         :param horizon: Int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
-        :return: A pd.DataFrame with the forecast components.
+       :param future_df: Optional future input dataframe. This dataframe should contain 
+            the time series column and covariate columns if available. It is used as the 
+            input for generating predictions.
+        :return: A pd.DataFrame that represents the model's output. The predicted target 
+            column is named 'yhat'.
         """
-        return self._predict_impl(horizon, include_history)
+        if future_df is None:
+            future_df = self.make_future_dataframe(horizon=horizon or self._horizon, include_history=include_history)
+
+        if self._preprocess_func and self._split_col:
+            future_df = apply_preprocess_func(future_df, self._preprocess_func, self._split_col)
+        future_df.rename(columns={self._time_col: "ds"}, inplace=True)
+        return self._predict_impl(future_df)
 
     def predict(self, context: mlflow.pyfunc.model.PythonModelContext, model_input: pd.DataFrame) -> pd.Series:
         """
@@ -143,15 +153,7 @@ class ProphetModel(ForecastModel):
         test_df = model_input.copy()
 
         if self._preprocess_func and self._split_col:
-            # Apply the same preprocessing pipeline to test_df. The preprocessing function requires the "y" column 
-            # and the split column to be present, as they are used in the trial notebook. These columns are added 
-            # temporarily and removed after preprocessing.
-            # see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
-            # and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
-            test_df["y"] = None
-            test_df[self._split_col] = "prediction"
-            test_df = self._preprocess_func(test_df)
-            test_df.drop(columns=["y", self._split_col], inplace=True, errors="ignore")
+            test_df = apply_preprocess_func(test_df, self._preprocess_func, self._split_col)
 
         test_df.rename(columns={self._time_col: "ds"}, inplace=True)
         predict_df = self.model().predict(test_df)
@@ -260,28 +262,36 @@ class MultiSeriesProphetModel(ProphetModel):
         future_pd[self._id_cols] = df[self._id_cols].iloc[0]
         return future_pd
 
-    def predict_timeseries(self, horizon: int = None, include_history: bool = True) -> pd.DataFrame:
+    def predict_timeseries(self, horizon: int = None, include_history: bool = True, future_df: pd.DataFrame = None) -> pd.DataFrame:
         """
         Predict using the prophet model.
         :param horizon: Int number of periods to forecast forward.
         :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
-        :return: A pd.DataFrame with the forecast components.
+        :param future_df: Optional future input dataframe. This dataframe should contain 
+            the time series column and covariate columns if available. It is used as the 
+            input for generating predictions.
+        :return: A pd.DataFrame that represents the model's output. The predicted target 
+            column is named 'yhat'.
         """
         horizon=horizon or self._horizon
-        end_time = pd.Timestamp(self._timeseries_end)
-        future_df = make_future_dataframe(
-            start_time=self._timeseries_starts,
-            end_time=end_time,
-            horizon=horizon,
-            frequency_unit=self._frequency_unit,
-            frequency_quantity=self._frequency_quantity,
-            include_history=include_history,
-            groups=self._model_json.keys(),
-            identity_column_names=self._id_cols
-        )
+        if future_df is None:
+            end_time = pd.Timestamp(self._timeseries_end)
+            future_df = make_future_dataframe(
+                start_time=self._timeseries_starts,
+                end_time=end_time,
+                horizon=horizon,
+                frequency_unit=self._frequency_unit,
+                frequency_quantity=self._frequency_quantity,
+                include_history=include_history,
+                groups=self._model_json.keys(),
+                identity_column_names=self._id_cols
+            )
         future_df["ts_id"] = future_df[self._id_cols].apply(tuple, axis=1)
-        return future_df.groupby(self._id_cols).apply(lambda df: self._predict_impl(df, horizon, include_history)).reset_index()
+        if self._preprocess_func and self._split_col:
+            future_df = apply_preprocess_func(future_df, self._preprocess_func, self._split_col)
+        future_df.rename(columns={self._time_col: "ds"}, inplace=True)
+        return future_df.groupby(self._id_cols).apply(lambda df: self._predict_impl(df, horizon, include_history)).reset_index(drop=True)
 
     @staticmethod
     def get_reserved_cols() -> List[str]:
@@ -353,7 +363,6 @@ class MultiSeriesProphetModel(ProphetModel):
         predict_df = test_df.groupby(self._id_cols).apply(model_prediction).reset_index(drop=True)
         return_df = test_df.merge(predict_df, how="left", on=["ds"] + self._id_cols)
         return return_df["yhat"]
-
 
 def mlflow_prophet_log_model(prophet_model: Union[ProphetModel, MultiSeriesProphetModel],
                              sample_input: pd.DataFrame = None) -> None:

--- a/runtime/databricks/automl_runtime/forecast/prophet/model.py
+++ b/runtime/databricks/automl_runtime/forecast/prophet/model.py
@@ -45,21 +45,27 @@ class ProphetModel(ForecastModel):
     Prophet mlflow model wrapper for univariate forecasting.
     """
 
-    def __init__(self, model_json: Union[Dict[Tuple, str], str], horizon: int, frequency: str,
+    def __init__(self, 
+                 model_json: Union[Dict[Tuple, str], str], 
+                 horizon: int, 
+                 frequency_unit: str, 
+                 frequency_quantity: int,
                  time_col: str) -> None:
         """
         Initialize the mlflow Python model wrapper for mlflow
         :param model_json: json string of the Prophet model or
         the dictionary of json strings of Prophet model for multi-series forecasting
         :param horizon: Int number of periods to forecast forward.
-        :param frequency: the frequency of the time series
+        :param frequency_unit: the frequency unit of the time series
+        :param frequency_quantity: the frequency quantity of the time series
         :param time_col: the column name of the time column
         """
         self._model_json = model_json
         self._horizon = horizon
-        self._frequency = frequency
+        self._frequency_unit = frequency_unit
+        self._frequency_quantity = frequency_quantity
         self._time_col = time_col
-        self._is_quaterly = is_quaterly_alias(frequency)
+        self._is_quaterly = is_quaterly_alias(frequency_unit)
         super().__init__()
 
     def load_context(self, context: mlflow.pyfunc.model.PythonModelContext) -> None:
@@ -92,7 +98,8 @@ class ProphetModel(ForecastModel):
         :return: pd.Dataframe that extends forward from the end of self.history for the
         requested number of periods.
         """
-        offset_kwarg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[self._frequency]]
+        offset_kwarg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[self._frequency_unit]]
+        offset_kwarg = {key: value * self._frequency_quantity for key, value in offset_kwarg.items()}
         return self.model().make_future_dataframe(periods=horizon or self._horizon,
                                                   freq=pd.DateOffset(**offset_kwarg),
                                                   include_history=include_history)
@@ -144,7 +151,7 @@ class MultiSeriesProphetModel(ProphetModel):
     """
 
     def __init__(self, model_json: Dict[Tuple, str], timeseries_starts: Dict[Tuple, pd.Timestamp],
-                 timeseries_end: str, horizon: int, frequency: str, time_col: str, id_cols: List[str],
+                 timeseries_end: str, horizon: int, frequency_unit: str, frequency_quantity: int, time_col: str, id_cols: List[str],
                  ) -> None:
         """
         Initialize the mlflow Python model wrapper for mlflow
@@ -152,12 +159,14 @@ class MultiSeriesProphetModel(ProphetModel):
         :param timeseries_starts: the dictionary of pd.Timestamp as the starting time of each time series
         :param timeseries_end: the end time of the time series
         :param horizon: int number of periods to forecast forward
-        :param frequency: the frequency of the time series
+        :param frequency_unit: the frequency unit of the time series
+        :param frequency_quantity: the frequency quantity of the time series
         :param time_col: the column name of the time column
         :param id_cols: the column names of the identity columns for multi-series time series
         """
-        super().__init__(model_json, horizon, frequency, time_col)
-        self._frequency = frequency
+        super().__init__(model_json, horizon, frequency_unit, frequency_quantity, time_col)
+        self._frequency_unit = frequency_unit
+        self._frequency_quantity = frequency_quantity
         self._timeseries_end = timeseries_end
         self._timeseries_starts = timeseries_starts
         self._id_cols = id_cols
@@ -200,7 +209,8 @@ class MultiSeriesProphetModel(ProphetModel):
             start_time=self._timeseries_starts,
             end_time=end_time,
             horizon=horizon,
-            frequency=self._frequency,
+            frequency_unit=self._frequency_unit,
+            frequency_quantity=self._frequency_quantity,
             include_history=include_history,
             groups=groups,
             identity_column_names=self._id_cols
@@ -235,7 +245,8 @@ class MultiSeriesProphetModel(ProphetModel):
             start_time=self._timeseries_starts,
             end_time=end_time,
             horizon=horizon,
-            frequency=self._frequency,
+            frequency_unit=self._frequency_unit,
+            frequency_quantity=self._frequency_quantity,
             include_history=include_history,
             groups=self._model_json.keys(),
             identity_column_names=self._id_cols

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -26,7 +26,8 @@ def make_future_dataframe(
         start_time: Union[pd.Timestamp, Dict[Tuple, pd.Timestamp]],
         end_time: Union[pd.Timestamp, Dict[Tuple, pd.Timestamp]],
         horizon: int,
-        frequency: str,
+        frequency_unit: str,
+        frequency_quantity: int,
         include_history: bool = True,
         groups: List[Tuple] = None,
         identity_column_names: List[str] = None,
@@ -36,14 +37,15 @@ def make_future_dataframe(
     :param start_time: the dictionary of the starting time of each time series in training data.
     :param end_time: the dictionary of the end time of each time series in training data.
     :param horizon: int number of periods to forecast forward.
-    :param frequency: the frequency of the time series
+    :param frequency_unit: the frequency unit of the time series
+    :param frequency_quantity: the multiplier for the frequency.
     :param include_history:
     :param groups: the collection of group(s) to generate forecast predictions.
     :param identity_column_names: Column names of the identity columns
     :return: pd.DataFrame that extends forward
     """
     if groups is None:
-        return make_single_future_dataframe(start_time, end_time, horizon, frequency)
+        return make_single_future_dataframe(start_time, end_time, horizon, frequency_unit, frequency_quantity)
 
     future_df_list = []
     for group in groups:
@@ -55,7 +57,7 @@ def make_future_dataframe(
             group_end_time = end_time[group]
         else:
             group_end_time = end_time
-        df = make_single_future_dataframe(group_start_time, group_end_time, horizon, frequency, include_history)
+        df = make_single_future_dataframe(group_start_time, group_end_time, horizon, frequency_unit, frequency_quantity, include_history)
         for idx, identity_column_name in enumerate(identity_column_names):
             df[identity_column_name] = group[idx]
         future_df_list.append(df)
@@ -65,7 +67,8 @@ def make_single_future_dataframe(
         start_time: pd.Timestamp,
         end_time: pd.Timestamp,
         horizon: int,
-        frequency: str,
+        frequency_unit: str,
+        frequency_quantity: int,
         include_history: bool = True,
         column_name: str = "ds"
 ) -> pd.DataFrame:
@@ -74,29 +77,30 @@ def make_single_future_dataframe(
     :param start_time: The starting time of time series of the training data.
     :param end_time: The end time of time series of the training data.
     :param horizon: Int number of periods to forecast forward.
-    :param frequency: The frequency of the time series
+    :param frequency_unit: The frequency unit of the time series
+    :param frequency_quantity: The frequency quantity of the time series
     :param include_history: Boolean to include the historical dates in the data
             frame for predictions.
     :param column_name: column name of the time column. Default is "ds".
     :return:
     """
-    offset_freq = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[frequency]]
-    unit_offset = pd.DateOffset(**offset_freq)
+    offset_freq = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[frequency_unit]]
+    timestep_offset = pd.DateOffset(**offset_freq) * frequency_quantity
     end_time = pd.Timestamp(end_time)
 
     if include_history:
         start_time = start_time
     else:
-        start_time = end_time + unit_offset
+        start_time = end_time + timestep_offset
 
     date_rng = pd.date_range(
         start=start_time,
-        end=end_time + unit_offset*horizon,
-        freq=unit_offset
+        end=end_time + timestep_offset * horizon,
+        freq=timestep_offset
     )
     return pd.DataFrame(date_rng, columns=[column_name])
 
-def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str, frequency_quantity: int = 1) -> int:
+def get_validation_horizon(df: pd.DataFrame, horizon: int, frequency_unit: str, frequency_quantity: int = 1) -> int:
     """
     Return validation_horizon, which is the lesser of `horizon` and one quarter of the dataframe's timedelta
     Since the seasonality period is never more than half of the dataframe's timedelta,
@@ -104,7 +108,7 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str, frequency_
     behavior, and we enforce it for ARIMA.)
     :param df: pd.DataFrame of the historical data
     :param horizon: int number of time into the future for forecasting
-    :param unit: frequency unit of the time series, which must be a pandas offset alias
+    :param frequency_unit: frequency unit of the time series, which must be a pandas offset alias
     :param frequency_quantity: int multiplier for the frequency unit, representing the number of `unit`s 
         per time step in the dataframe. This is useful when the time series has a granularity that 
         spans multiple `unit`s (e.g., if `unit='min'` and `frequency_quantity=5`, it means the data 
@@ -112,7 +116,7 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str, frequency_
     :return: horizon used for validation, in terms of the input `unit`
     """
     MIN_HORIZONS = 4  # minimum number of horizons in the dataframe
-    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit]) * horizon * frequency_quantity
+    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit]) * horizon * frequency_quantity
 
     try:
         if MIN_HORIZONS * horizon_dateoffset + df["ds"].min() <= df["ds"].max():
@@ -123,7 +127,7 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str, frequency_
     # In order to calculate the validation horizon, we incrementally add offset
     # to the start time to the quarter of total timedelta. We did this since
     # pd.DateOffset does not support divide by operation.
-    timestep_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit]) * frequency_quantity
+    timestep_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit]) * frequency_quantity
     max_horizon = 0
     cur_timestamp = df["ds"].min()
     while cur_timestamp + timestep_dateoffset <= df["ds"].max():
@@ -133,36 +137,38 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str, frequency_
     f"timedelta. Validation horizon will be reduced to {max_horizon//MIN_HORIZONS*timestep_dateoffset}.")
     return max_horizon // MIN_HORIZONS
 
-def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
+def generate_cutoffs(df: pd.DataFrame, horizon: int, frequency_unit: str,
                      num_folds: int, seasonal_period: int = 0, 
-                     seasonal_unit: Optional[str] = None) -> List[pd.Timestamp]:
+                     seasonal_unit: Optional[str] = None,
+                     frequency_quantity: int = 1) -> List[pd.Timestamp]:
     """
     Generate cutoff times for cross validation with the control of number of folds.
     :param df: pd.DataFrame of the historical data.
     :param horizon: int number of time into the future for forecasting.
-    :param unit: frequency unit of the time series, which must be a pandas offset alias.
+    :param frequency_unit: frequency unit of the time series, which must be a pandas offset alias.
     :param num_folds: int number of cutoffs for cross validation.
     :param seasonal_period: length of the seasonality period.
     :param seasonal_unit: Optional frequency unit for the seasonal period. If not specified, the function will use
                           the same frequency unit as the time series.
+    :param frequency_quantity: frequency quantity of the time series.
     :return: list of pd.Timestamp cutoffs for cross-validation.
     """
     period = max(0.5 * horizon, 1)  # avoid empty cutoff buckets
 
     # avoid non-integer months, quaters ands years.
-    if unit in NON_DAILY_OFFSET_ALIAS:
+    if frequency_unit in NON_DAILY_OFFSET_ALIAS:
         period = int(period)
-        period_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])*period
+        period_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit])*frequency_quantity*period
     else:
-        offset_kwarg = {list(DATE_OFFSET_KEYWORD_MAP[unit])[0]: period}
-        period_dateoffset = pd.DateOffset(**offset_kwarg)
+        offset_kwarg = {list(DATE_OFFSET_KEYWORD_MAP[frequency_unit])[0]: period}
+        period_dateoffset = pd.DateOffset(**offset_kwarg) * frequency_quantity
 
-    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])*horizon
+    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit])*frequency_quantity*horizon
 
     if not seasonal_unit:
-        seasonal_unit = unit
+        seasonal_unit = frequency_unit
 
-    seasonality_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])*seasonal_period
+    seasonality_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit])*frequency_quantity*seasonal_period
 
     # We can not compare DateOffset directly, so we add to start time and compare.
     initial = seasonality_dateoffset
@@ -191,23 +197,24 @@ def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
         )
     return list(reversed(result))
 
-def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, unit: str,
-                     split_cutoff: pd.Timestamp) -> List[pd.Timestamp]:
+def generate_custom_cutoffs(df: pd.DataFrame, horizon: int, frequency_unit: str,
+                     split_cutoff: pd.Timestamp, frequency_quantity: int = 1) -> List[pd.Timestamp]:
     """
     Generate custom cutoff times for cross validation based on user-specified split cutoff.
     Period (step size) is 1.
     :param df: pd.DataFrame of the historical data.
     :param horizon: int number of time into the future for forecasting.
-    :param unit: frequency unit of the time series, which must be a pandas offset alias.
+    :param frequency_unit: frequency unit of the time series, which must be a pandas offset alias.
     :param split_cutoff: the user-specified cutoff, as the starting point of cutoffs.
+    :param frequency_quantity: frequency quantity of the time series.
     For tuning job, it is the cutoff between train and validate split.
     For training job, it is the cutoff bewteen validate and test split.
     :return: list of pd.Timestamp cutoffs for cross-validation.
     """
     # TODO: [ML-43528] expose period as input.
     period = 1 
-    period_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])*period
-    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])*horizon
+    period_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit])*period*frequency_quantity
+    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[frequency_unit])*horizon*frequency_quantity
 
     # First cutoff is the cutoff bewteen splits
     cutoff = split_cutoff
@@ -229,7 +236,8 @@ def is_quaterly_alias(freq: str):
 def is_frequency_consistency(
                 start_time: pd.Timestamp,
                 end_time: pd.Timestamp, 
-                freq:str) -> bool:
+                frequency_unit:str,
+                frequency_quantity: int) -> bool:
     """
     Validate the periods given a start time, end time is consistent with given frequency.
     We consider consistency as only integer frequencies between start and end time, e.g.
@@ -239,30 +247,35 @@ def is_frequency_consistency(
     :param end_time: A pandas timestamp.
     :param freq: A string that is accepted by OFFSET_ALIAS_MAP, e.g. 'day',
                 'month' etc.
+    :param frequency_quantity: the multiplier for the frequency.
     :return: A boolean indicate whether the time interval is
              evenly divisible by the period.
     """
-    periods = calculate_period_differences(start_time, end_time, freq)
-    diff = pd.to_datetime(end_time) -  pd.DateOffset(
-                **DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[freq]]
-            ) * periods == pd.to_datetime(start_time)
+    periods = calculate_period_differences(start_time, end_time, frequency_unit, frequency_quantity)
+    # If the difference between start and end time is divisible by the period time
+    diff = (pd.to_datetime(end_time) -  pd.DateOffset(
+                **DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[frequency_unit]]
+            ) * periods * frequency_quantity) == pd.to_datetime(start_time)
     return diff
 
 
 def calculate_period_differences(
                 start_time: pd.Timestamp,
                 end_time: pd.Timestamp, 
-                freq:str) -> int:
+                frequency_unit:str,
+                frequency_quantity: int) -> int:
     """
     Calculate the periods given a start time, end time and period frequency.
     :param start_time: A pandas timestamp.
     :param end_time: A pandas timestamp.
     :param freq: A string that is accepted by OFFSET_ALIAS_MAP, e.g. 'day',
                 'month' etc.
+    :param frequency_quantity: An integer that is the multiplier for the frequency.
     :return: A pd.Series indicates the round-down integer period
              calculated.
     """
     start_time = pd.to_datetime(start_time)
     end_time = pd.to_datetime(end_time)
-    freq_alias = PERIOD_ALIAS_MAP[OFFSET_ALIAS_MAP[freq]]
-    return  (end_time.to_period(freq_alias) - start_time.to_period(freq_alias)).n
+    freq_alias = PERIOD_ALIAS_MAP[OFFSET_ALIAS_MAP[frequency_unit]]
+    # It is intended to get the floor value. And in the later check we will use this floor value to find out if it is not consistent.
+    return  (end_time.to_period(freq_alias) - start_time.to_period(freq_alias)).n // frequency_quantity

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -279,3 +279,21 @@ def calculate_period_differences(
     freq_alias = PERIOD_ALIAS_MAP[OFFSET_ALIAS_MAP[frequency_unit]]
     # It is intended to get the floor value. And in the later check we will use this floor value to find out if it is not consistent.
     return  (end_time.to_period(freq_alias) - start_time.to_period(freq_alias)).n // frequency_quantity
+
+def apply_preprocess_func(df: pd.DataFrame, preprocess_func: callable, split_col: str) -> pd.DataFrame:
+    """
+    Apply the preprocessing function to the dataframe. The preprocessing function requires the "y" column
+    and the split column to be present, as they are used in the trial notebook. These columns are added
+    temporarily and removed after preprocessing.
+    see https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/finish_with_transform.jinja?L3
+    and https://src.dev.databricks.com/databricks-eng/universe/-/blob/automl/python/databricks/automl/core/sections/templates/preprocess/select_columns.jinja?L8-10
+    :param df: pd.DataFrame to be preprocessed.
+    :param preprocess_func: preprocessing function to be applied to the dataframe.
+    :param split_col: name of the split column to be added to the dataframe.
+    :return: preprocessed pd.DataFrame.
+    """
+    df["y"] = None
+    df[split_col] = "prediction"
+    df = preprocess_func(df)
+    df.drop(columns=["y", split_col], inplace=True, errors="ignore")
+    return df

--- a/runtime/databricks/automl_runtime/forecast/utils.py
+++ b/runtime/databricks/automl_runtime/forecast/utils.py
@@ -96,7 +96,7 @@ def make_single_future_dataframe(
     )
     return pd.DataFrame(date_rng, columns=[column_name])
 
-def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
+def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str, frequency_quantity: int = 1) -> int:
     """
     Return validation_horizon, which is the lesser of `horizon` and one quarter of the dataframe's timedelta
     Since the seasonality period is never more than half of the dataframe's timedelta,
@@ -105,10 +105,14 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
     :param df: pd.DataFrame of the historical data
     :param horizon: int number of time into the future for forecasting
     :param unit: frequency unit of the time series, which must be a pandas offset alias
+    :param frequency_quantity: int multiplier for the frequency unit, representing the number of `unit`s 
+        per time step in the dataframe. This is useful when the time series has a granularity that 
+        spans multiple `unit`s (e.g., if `unit='min'` and `frequency_quantity=5`, it means the data 
+        follows a five-minute pattern). To make it backward compatible, defaults to 1.
     :return: horizon used for validation, in terms of the input `unit`
     """
     MIN_HORIZONS = 4  # minimum number of horizons in the dataframe
-    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit]) * horizon
+    horizon_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit]) * horizon * frequency_quantity
 
     try:
         if MIN_HORIZONS * horizon_dateoffset + df["ds"].min() <= df["ds"].max():
@@ -119,14 +123,14 @@ def get_validation_horizon(df: pd.DataFrame, horizon: int, unit: str) -> int:
     # In order to calculate the validation horizon, we incrementally add offset
     # to the start time to the quarter of total timedelta. We did this since
     # pd.DateOffset does not support divide by operation.
-    unit_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit])
+    timestep_dateoffset = pd.DateOffset(**DATE_OFFSET_KEYWORD_MAP[unit]) * frequency_quantity
     max_horizon = 0
     cur_timestamp = df["ds"].min()
-    while cur_timestamp + unit_dateoffset <= df["ds"].max():
-        cur_timestamp += unit_dateoffset
+    while cur_timestamp + timestep_dateoffset <= df["ds"].max():
+        cur_timestamp += timestep_dateoffset
         max_horizon += 1
     _logger.info(f"Horizon {horizon_dateoffset} too long relative to dataframe's "
-    f"timedelta. Validation horizon will be reduced to {max_horizon//MIN_HORIZONS*unit_dateoffset}.")
+    f"timedelta. Validation horizon will be reduced to {max_horizon//MIN_HORIZONS*timestep_dateoffset}.")
     return max_horizon // MIN_HORIZONS
 
 def generate_cutoffs(df: pd.DataFrame, horizon: int, unit: str,

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.3.dev"  # pragma: no cover
+__version__ = "0.2.20.3"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20"  # pragma: no cover
+__version__ = "0.2.20.1"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.1"  # pragma: no cover
+__version__ = "0.2.20.2.dev0"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.2.dev0"  # pragma: no cover
+__version__ = "0.2.20.2"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.2"  # pragma: no cover
+__version__ = "0.2.20.3.dev"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.4"  # pragma: no cover
+__version__ = "0.2.20.5.dev0"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.3"  # pragma: no cover
+__version__ = "0.2.20.4"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.6"  # pragma: no cover
+__version__ = "0.2.20.7"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.8"  # pragma: no cover
+__version__ = "0.2.20.9"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.5"  # pragma: no cover
+__version__ = "0.2.20.6"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.7"  # pragma: no cover
+__version__ = "0.2.20.8"  # pragma: no cover

--- a/runtime/databricks/automl_runtime/version.py
+++ b/runtime/databricks/automl_runtime/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.20.5.dev0"  # pragma: no cover
+__version__ = "0.2.20.5"  # pragma: no cover

--- a/runtime/environment.txt
+++ b/runtime/environment.txt
@@ -2,8 +2,10 @@
 # * Keep dependencies sorted.
 
 category_encoders==2.6.0
+gluonts[torch]==0.15.1
 holidays==0.28
 hyperopt==0.2.7
+lightning==2.0.1
 mlflow==2.0.1
 numpy==1.23.5
 pandas==1.5.3
@@ -11,4 +13,5 @@ pmdarima==2.0.3
 prophet==1.1.4
 pyarrow==8.0.0
 scikit-learn==1.1.1
+torch==2.0.1
 wrapt==1.14.1

--- a/runtime/requirements.txt
+++ b/runtime/requirements.txt
@@ -2,6 +2,7 @@
 # * Keep dependencies sorted.
 
 category_encoders
+gluonts
 holidays
 hyperopt
 mlflow
@@ -13,4 +14,6 @@ prophet
 pyarrow
 requests
 scikit-learn
+torch
+lightning
 wrapt

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -46,6 +46,7 @@ setup(
         "databricks",
         "databricks.automl_runtime",
         "databricks.automl_runtime.forecast",
+        "databricks.automl_runtime.forecast.deepar",
         "databricks.automl_runtime.forecast.pmdarima",
         "databricks.automl_runtime.forecast.prophet",
         "databricks.automl_runtime.hyperopt",

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -1,0 +1,154 @@
+#
+# Copyright (C) 2024 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+import mlflow
+import pandas as pd
+import torch
+import torch.nn as nn
+from gluonts.dataset.field_names import FieldName
+from gluonts.transform import InstanceSplitter, TestSplitSampler
+from gluonts.torch.model.predictor import PyTorchPredictor
+
+from databricks.automl_runtime.forecast.deepar.model import (
+    DeepARModel, mlflow_deepar_log_model,
+)
+
+
+class TestDeepARModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Adapted from https://github.com/awslabs/gluonts/blob/dev/test/torch/model/test_torch_predictor.py
+        class RandomNetwork(nn.Module):
+            def __init__(
+                    self,
+                    prediction_length: int,
+                    context_length: int,
+            ) -> None:
+                super().__init__()
+                self.prediction_length = prediction_length
+                self.context_length = context_length
+                self.net = nn.Linear(context_length, prediction_length)
+                torch.nn.init.uniform_(self.net.weight, -1.0, 1.0)
+
+            def forward(self, past_target):
+                out = self.net(past_target.float())
+                return out.unsqueeze(1)
+
+        cls.context_length = 5
+        cls.prediction_length = 5
+
+        cls.pred_net = RandomNetwork(
+            prediction_length=cls.context_length, context_length=cls.context_length
+        )
+
+        cls.transformation = InstanceSplitter(
+            target_field=FieldName.TARGET,
+            is_pad_field=FieldName.IS_PAD,
+            start_field=FieldName.START,
+            forecast_start_field=FieldName.FORECAST_START,
+            instance_sampler=TestSplitSampler(),
+            past_length=cls.context_length,
+            future_length=cls.prediction_length,
+        )
+
+        cls.model = PyTorchPredictor(
+            prediction_length=cls.prediction_length,
+            input_names=["past_target"],
+            prediction_net=cls.pred_net,
+            batch_size=16,
+            input_transform=cls.transformation,
+            device="cpu",
+        )
+
+    def test_model_save_and_load_single_series(self):
+        target_col = "sales"
+        time_col = "date"
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            num_samples=1,
+            target_col=target_col,
+            time_col=time_col,
+        )
+
+        num_rows = 10
+        sample_input = pd.concat(
+            [
+                pd.to_datetime(
+                    pd.Series(range(num_rows), name=time_col).apply(
+                        lambda i: f"2020-10-{3 * i + 1}"
+                    )
+                ),
+                pd.Series(range(num_rows), name=target_col),
+            ],
+            axis=1,
+        )
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+
+        run_id = run.info.run_id
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+
+        pred_df = loaded_model.predict(sample_input)
+
+        assert pred_df.columns.tolist() == [time_col, "yhat"]
+        assert len(pred_df) == self.prediction_length
+        assert pred_df[time_col].min() > sample_input[time_col].max()
+
+    def test_model_save_and_load_multi_series(self):
+        target_col = "sales"
+        time_col = "date"
+        id_col = "store"
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            num_samples=1,
+            target_col=target_col,
+            time_col=time_col,
+            id_cols=[id_col],
+        )
+
+        num_rows = 10
+        sample_input_base = pd.concat(
+            [
+                pd.to_datetime(
+                    pd.Series(range(num_rows), name=time_col).apply(
+                        lambda i: f"2020-10-{3 * i + 1}"
+                    )
+                ),
+                pd.Series(range(num_rows), name=target_col),
+            ],
+            axis=1,
+        )
+        sample_input = pd.concat([sample_input_base.copy(), sample_input_base.copy()], ignore_index=True)
+        sample_input[id_col] = [1] * num_rows + [2] * num_rows
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+
+        run_id = run.info.run_id
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+
+        pred_df = loaded_model.predict(sample_input)
+
+        assert pred_df.columns.tolist() == [time_col, "yhat", id_col]
+        assert len(pred_df) == self.prediction_length * 2
+        assert pred_df[time_col].min() > sample_input[time_col].max()

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -25,7 +25,9 @@ from gluonts.transform import InstanceSplitter, TestSplitSampler
 from gluonts.torch.model.predictor import PyTorchPredictor
 
 from databricks.automl_runtime.forecast.deepar.model import (
-    DeepARModel, mlflow_deepar_log_model,
+    DeepARModel, 
+    mlflow_deepar_log_model, 
+    DEEPAR_ADDITIONAL_PIP_DEPS
 )
 
 
@@ -104,8 +106,12 @@ class TestDeepARModel(unittest.TestCase):
             mlflow_deepar_log_model(deepar_model, sample_input)
 
         run_id = run.info.run_id
-        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
 
+        # check if all additional dependencies are logged
+        self._check_requirements(run_id)
+
+        # load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
         pred_df = loaded_model.predict(sample_input)
 
         assert pred_df.columns.tolist() == [time_col, "yhat"]
@@ -145,10 +151,23 @@ class TestDeepARModel(unittest.TestCase):
             mlflow_deepar_log_model(deepar_model, sample_input)
 
         run_id = run.info.run_id
-        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
 
+        # check if all additional dependencies are logged
+        self._check_requirements(run_id)
+
+        # load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
         pred_df = loaded_model.predict(sample_input)
 
         assert pred_df.columns.tolist() == [time_col, "yhat", id_col]
         assert len(pred_df) == self.prediction_length * 2
         assert pred_df[time_col].min() > sample_input[time_col].max()
+
+    def _check_requirements(self, run_id: str):
+        # read requirements.txt from the run
+        requirements_path = mlflow.artifacts.download_artifacts(f"runs:/{run_id}/model/requirements.txt")
+        with open(requirements_path, "r") as f:
+            requirements = f.read()
+        # check if all additional dependencies are logged
+        for dependency in DEEPAR_ADDITIONAL_PIP_DEPS:
+            self.assertIn(dependency, requirements, f"requirements.txt should contain {dependency} but got {requirements}")

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -20,6 +20,7 @@ import mlflow
 import pandas as pd
 import torch
 import torch.nn as nn
+from parameterized import parameterized
 from gluonts.dataset.field_names import FieldName
 from gluonts.transform import InstanceSplitter, TestSplitSampler
 from gluonts.torch.model.predictor import PyTorchPredictor
@@ -93,7 +94,8 @@ class TestDeepARModel(unittest.TestCase):
         deepar_model = DeepARModel(
             model=self.model,
             horizon=self.prediction_length,
-            frequency="d",
+            frequency_unit="d",
+            frequency_quantity=1,
             num_samples=1,
             target_col=target_col,
             time_col=time_col,
@@ -137,7 +139,8 @@ class TestDeepARModel(unittest.TestCase):
             model=self.model,
             horizon=self.prediction_length,
             num_samples=1,
-            frequency="d",
+            frequency_unit="d",
+            frequency_quantity=1,
             target_col=target_col,
             time_col=time_col,
             id_cols=[id_col],
@@ -184,7 +187,8 @@ class TestDeepARModel(unittest.TestCase):
             model=self.model,
             horizon=self.prediction_length,
             num_samples=1,
-            frequency="d",
+            frequency_unit="d",
+            frequency_quantity=1,
             target_col=target_col,
             time_col=time_col,
             id_cols=id_cols,
@@ -230,7 +234,8 @@ class TestDeepARModel(unittest.TestCase):
         deepar_model = DeepARModel(
             model=self.model,
             horizon=self.prediction_length,
-            frequency="d",
+            frequency_unit="d",
+            frequency_quantity=1,
             num_samples=1,
             target_col=target_col,
             time_col=time_col,
@@ -273,7 +278,8 @@ class TestDeepARModel(unittest.TestCase):
         deepar_model = DeepARModel(
             model=self.model,
             horizon=self.prediction_length,
-            frequency="MS",
+            frequency_unit="MS",
+            frequency_quantity=1,
             num_samples=1,
             target_col=target_col,
             time_col=time_col,
@@ -284,6 +290,46 @@ class TestDeepARModel(unittest.TestCase):
             "2020-10-01", "2020-11-01", "2020-12-01",
             "2021-01-01", "2021-02-01", "2021-03-01"
         ])
+
+        sales = [10, 20, 30, 
+                 60, 90, 100]
+
+        sample_input = pd.DataFrame({
+            time_col: dates,
+            target_col: sales
+        })
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+
+        run_id = run.info.run_id
+
+        # Load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+        pred_df = loaded_model.predict(sample_input)
+
+        # Verify the prediction output format
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
+        self.assertEqual(len(pred_df), self.prediction_length)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
+
+    @parameterized.expand([(1,), (5,), (10,), (15,), (30,)])
+    def test_model_prediction_with_multiple_minutes_frequency(self, frequency_quantity):
+        target_col = "sales"
+        time_col = "date"
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            frequency_unit="min",
+            frequency_quantity=frequency_quantity,
+            num_samples=1,
+            target_col=target_col,
+            time_col=time_col,
+        )
+
+        # Create sample input with duplicate timestamps
+        dates = pd.date_range(start="2020-10-01", periods=6, freq=f"{frequency_quantity}min")
 
         sales = [10, 20, 30, 
                  60, 90, 100]

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -77,6 +77,15 @@ class TestDeepARModel(unittest.TestCase):
             device="cpu",
         )
 
+    def _check_requirements(self, run_id: str):
+        # read requirements.txt from the run
+        requirements_path = mlflow.artifacts.download_artifacts(f"runs:/{run_id}/model/requirements.txt")
+        with open(requirements_path, "r") as f:
+            requirements = f.read()
+        # check if all additional dependencies are logged
+        for dependency in DEEPAR_ADDITIONAL_PIP_DEPS:
+            self.assertIn(dependency, requirements, f"requirements.txt should contain {dependency} but got {requirements}")
+
     def test_model_save_and_load_single_series(self):
         target_col = "sales"
         time_col = "date"
@@ -210,11 +219,49 @@ class TestDeepARModel(unittest.TestCase):
         self.assertEqual(len(pred_df), self.prediction_length * 4)
         self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
 
-    def _check_requirements(self, run_id: str):
-        # read requirements.txt from the run
-        requirements_path = mlflow.artifacts.download_artifacts(f"runs:/{run_id}/model/requirements.txt")
-        with open(requirements_path, "r") as f:
-            requirements = f.read()
-        # check if all additional dependencies are logged
-        for dependency in DEEPAR_ADDITIONAL_PIP_DEPS:
-            self.assertIn(dependency, requirements, f"requirements.txt should contain {dependency} but got {requirements}")
+    def test_model_prediction_with_duplicate_timestamps(self):
+        """
+        Test that the model correctly handles and averages multiple rows with the same timestamp
+        when identity columns are not provided.
+        """
+        target_col = "sales"
+        time_col = "date"
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            frequency="d",
+            num_samples=1,
+            target_col=target_col,
+            time_col=time_col,
+        )
+
+        # Create sample input with duplicate timestamps
+        dates = pd.to_datetime([
+            "2020-10-01", "2020-10-01",  # duplicate date with different values
+            "2020-10-04", "2020-10-04", "2020-10-04",  # triple duplicate
+            "2020-10-07"  # single entry
+        ])
+
+        sales = [10, 20,  # should average to 15
+                 30, 60, 90,  # should average to 60
+                 100]  # single value stays 100
+
+        sample_input = pd.DataFrame({
+            time_col: dates,
+            target_col: sales
+        })
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+
+        run_id = run.info.run_id
+
+        # Load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+        pred_df = loaded_model.predict(sample_input)
+
+        # Verify the prediction output format
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
+        self.assertEqual(len(pred_df), self.prediction_length)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())

--- a/runtime/tests/automl_runtime/forecast/deepar/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/model_test.py
@@ -265,3 +265,44 @@ class TestDeepARModel(unittest.TestCase):
         self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
         self.assertEqual(len(pred_df), self.prediction_length)
         self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())
+
+    def test_model_prediction_with_monthly_data(self):
+        target_col = "sales"
+        time_col = "date"
+
+        deepar_model = DeepARModel(
+            model=self.model,
+            horizon=self.prediction_length,
+            frequency="MS",
+            num_samples=1,
+            target_col=target_col,
+            time_col=time_col,
+        )
+
+        # Create sample input with duplicate timestamps
+        dates = pd.to_datetime([
+            "2020-10-01", "2020-11-01", "2020-12-01",
+            "2021-01-01", "2021-02-01", "2021-03-01"
+        ])
+
+        sales = [10, 20, 30, 
+                 60, 90, 100]
+
+        sample_input = pd.DataFrame({
+            time_col: dates,
+            target_col: sales
+        })
+
+        with mlflow.start_run() as run:
+            mlflow_deepar_log_model(deepar_model, sample_input)
+
+        run_id = run.info.run_id
+
+        # Load the model and predict
+        loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+        pred_df = loaded_model.predict(sample_input)
+
+        # Verify the prediction output format
+        self.assertEqual(pred_df.columns.tolist(), [time_col, "yhat"])
+        self.assertEqual(len(pred_df), self.prediction_length)
+        self.assertGreater(pred_df[time_col].min(), sample_input[time_col].max())

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -1,0 +1,110 @@
+#
+# Copyright (C) 2024 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+import pandas as pd
+
+from databricks.automl_runtime.forecast.deepar.utils import set_index_and_fill_missing_time_steps
+
+
+class TestDeepARUtils(unittest.TestCase):
+    def test_single_series_filled(self):
+        target_col = "sales"
+        time_col = "date"
+        num_rows = 10
+
+        base_df = pd.concat(
+            [
+                pd.to_datetime(
+                    pd.Series(range(num_rows), name=time_col).apply(
+                        lambda i: f"2020-10-{i + 1}"
+                    )
+                ),
+                pd.Series(range(num_rows), name=target_col),
+            ],
+            axis=1,
+        )
+        dropped_df = base_df.drop([4, 5]).reset_index(drop=True)
+
+        transformed_df = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D")
+
+        expected_df = base_df.copy()
+        expected_df.loc[[4, 5], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None).asfreq("D")
+
+        pd.testing.assert_frame_equal(transformed_df, expected_df)
+
+    def test_multi_series_filled(self):
+        target_col = "sales"
+        time_col = "date"
+        id_col = "store"
+
+        num_rows_per_ts = 10
+        base_df = pd.concat(
+            [
+                pd.to_datetime(
+                    pd.Series(range(num_rows_per_ts), name=time_col).apply(
+                        lambda i: f"2020-10-{i + 1}"
+                    )
+                ),
+                pd.Series(range(num_rows_per_ts), name=target_col),
+            ],
+            axis=1,
+        )
+        dropped_base_df = base_df.drop([4, 5]).reset_index(drop=True)
+        dropped_df = pd.concat([dropped_base_df.copy(), dropped_base_df.copy()], ignore_index=True)
+        dropped_df[id_col] = [1] * (num_rows_per_ts - 2) + [2] * (num_rows_per_ts - 2)
+
+        transformed_df_dict = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D", id_cols=[id_col])
+        self.assertEqual(transformed_df_dict.keys(), {"1", "2"})
+
+        expected_first_df = base_df.copy()
+        expected_first_df.loc[[4, 5], target_col] = float('nan')
+        expected_first_df = expected_first_df.set_index(time_col).rename_axis(None).asfreq("D")
+
+        pd.testing.assert_frame_equal(transformed_df_dict["1"], expected_first_df)
+
+    def test_multi_series_multi_id_cols_filled(self):
+        target_col = "sales"
+        time_col = "date"
+        id_cols = ["store", "dept"]
+
+        num_rows_per_ts = 10
+        base_df = pd.concat(
+            [
+                pd.to_datetime(
+                    pd.Series(range(num_rows_per_ts), name=time_col).apply(
+                        lambda i: f"2020-10-{i + 1}"
+                    )
+                ),
+                pd.Series(range(num_rows_per_ts), name=target_col),
+            ],
+            axis=1,
+        )
+        dropped_base_df = base_df.drop([4, 5]).reset_index(drop=True)
+        dropped_df = pd.concat([dropped_base_df.copy(), dropped_base_df.copy(),
+                                dropped_base_df.copy(), dropped_base_df.copy()], ignore_index=True)
+        dropped_df[id_cols[0]] = ([1] * (num_rows_per_ts - 2) + [2] * (num_rows_per_ts - 2)) * 2
+        dropped_df[id_cols[1]] = [1] * (2 * (num_rows_per_ts - 2)) + [2] * (2 * (num_rows_per_ts - 2))
+
+        transformed_df_dict = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D", id_cols=id_cols)
+        self.assertEqual(transformed_df_dict.keys(), {"1-1", "1-2", "2-1", "2-2"})
+
+        expected_first_df = base_df.copy()
+        expected_first_df.loc[[4, 5], target_col] = float('nan')
+        expected_first_df = expected_first_df.set_index(time_col).rename_axis(None).asfreq("D")
+
+        pd.testing.assert_frame_equal(transformed_df_dict["1-1"], expected_first_df)

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -108,3 +108,38 @@ class TestDeepARUtils(unittest.TestCase):
         expected_first_df = expected_first_df.set_index(time_col).rename_axis(None).asfreq("D")
 
         pd.testing.assert_frame_equal(transformed_df_dict["1-1"], expected_first_df)
+
+    def test_single_series_week_day_index(self):
+        target_col = "sales"
+        time_col = "date"
+        num_weeks = 10
+
+        # Starting from first Friday in 2020
+        base_dates = pd.date_range(
+            start='2020-01-03',  # First Friday of 2020
+            periods=num_weeks,
+            freq='W-FRI'  # Weekly frequency starting Friday
+        )
+
+        base_df = pd.DataFrame({
+            time_col: base_dates,
+            target_col: range(num_weeks)
+        })
+
+        # Create a dataframe with missing weeks (drop weeks 3 and 4)
+        dropped_df = base_df.drop([3, 4]).reset_index(drop=True)
+
+        # Transform the dataframe
+        transformed_df = set_index_and_fill_missing_time_steps(
+            dropped_df,
+            time_col,
+            "W" # Weekly frequency **without** specifying Friday
+        )
+
+        # Create expected dataframe
+        expected_df = base_df.copy()
+        expected_df.loc[[3, 4], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None).asfreq("W-FRI")
+
+        # Assert equality
+        pd.testing.assert_frame_equal(transformed_df, expected_df)

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -289,3 +289,45 @@ class TestDeepARUtils(unittest.TestCase):
 
         # Assert equality
         pd.testing.assert_frame_equal(transformed_df, expected_df)
+
+    def test_multi_timeseries_month_start_index(self):
+        """Test that monthly frequency data is properly truncated to period for multiple series"""
+        target_col = "sales"
+        time_col = "date"
+        num_months = 24
+        id_col = "store"
+
+        # Create data with varying days of month for two stores
+        # Starting from first day of January 2020
+        base_dates = pd.date_range(
+            start='2020-01-01',
+            periods=num_months,
+            freq='MS'
+        )
+
+        base_df = pd.DataFrame({
+            time_col: base_dates,
+            target_col: range(num_months) 
+        })
+
+        # Create a dataframe with missing months (drop months 3 and 4)
+        dropped_base_df = base_df.drop([3, 4]).reset_index(drop=True)
+        dropped_df = pd.concat([dropped_base_df.copy(), dropped_base_df.copy()],
+                               ignore_index=True)
+        dropped_df[id_col] = [1] * (num_months - 2) + [2] * (num_months - 2)
+        # Transform the dataframe
+        transformed_df_dict = set_index_and_fill_missing_time_steps(
+            dropped_df,
+            time_col,
+            "MS", # Monthly frequency
+            1,
+            id_cols=[id_col]
+        )
+
+        # Create expected dataframe for one series
+        expected_df = base_df.copy()
+        expected_df.loc[[3, 4], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None).to_period("M")
+         # Assert equality
+        self.assertEqual(transformed_df_dict.keys(), {'1', '2'})
+        pd.testing.assert_frame_equal(transformed_df_dict["1"], expected_df) 

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -16,6 +16,7 @@
 import unittest
 
 import pandas as pd
+from parameterized import parameterized
 
 from databricks.automl_runtime.forecast.deepar.utils import set_index_and_fill_missing_time_steps
 
@@ -39,7 +40,7 @@ class TestDeepARUtils(unittest.TestCase):
         )
         dropped_df = base_df.drop([4, 5]).reset_index(drop=True)
 
-        transformed_df = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D")
+        transformed_df = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D", 1)
 
         expected_df = base_df.copy()
         expected_df.loc[[4, 5], target_col] = float('nan')
@@ -68,7 +69,7 @@ class TestDeepARUtils(unittest.TestCase):
         dropped_df = pd.concat([dropped_base_df.copy(), dropped_base_df.copy()], ignore_index=True)
         dropped_df[id_col] = [1] * (num_rows_per_ts - 2) + [2] * (num_rows_per_ts - 2)
 
-        transformed_df_dict = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D", id_cols=[id_col])
+        transformed_df_dict = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D", 1, id_cols=[id_col])
         self.assertEqual(transformed_df_dict.keys(), {"1", "2"})
 
         expected_first_df = base_df.copy()
@@ -100,7 +101,7 @@ class TestDeepARUtils(unittest.TestCase):
         dropped_df[id_cols[0]] = ([1] * (num_rows_per_ts - 2) + [2] * (num_rows_per_ts - 2)) * 2
         dropped_df[id_cols[1]] = [1] * (2 * (num_rows_per_ts - 2)) + [2] * (2 * (num_rows_per_ts - 2))
 
-        transformed_df_dict = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D", id_cols=id_cols)
+        transformed_df_dict = set_index_and_fill_missing_time_steps(dropped_df, time_col, "D", 1, id_cols=id_cols)
         self.assertEqual(transformed_df_dict.keys(), {"1-1", "1-2", "2-1", "2-2"})
 
         expected_first_df = base_df.copy()
@@ -133,7 +134,8 @@ class TestDeepARUtils(unittest.TestCase):
         transformed_df = set_index_and_fill_missing_time_steps(
             dropped_df,
             time_col,
-            "W" # Weekly frequency **without** specifying Friday
+            "W", # Weekly frequency **without** specifying Friday
+            1
         )
 
         # Create expected dataframe
@@ -168,7 +170,8 @@ class TestDeepARUtils(unittest.TestCase):
         transformed_df = set_index_and_fill_missing_time_steps(
             dropped_df,
             time_col,
-            "MS" # Monthly frequency
+            "MS", # Monthly frequency
+            1
         )
 
         # Create expected dataframe
@@ -204,7 +207,8 @@ class TestDeepARUtils(unittest.TestCase):
         transformed_df = set_index_and_fill_missing_time_steps(
             dropped_df,
             time_col,
-            "MS"
+            "MS",
+            1
         )
 
         # Create expected dataframe
@@ -241,7 +245,8 @@ class TestDeepARUtils(unittest.TestCase):
         transformed_df = set_index_and_fill_missing_time_steps(
             dropped_df,
             time_col,
-            "MS" # Monthly frequency
+            "MS", # Monthly frequency
+            1
         )
 
         # Create expected dataframe
@@ -249,6 +254,38 @@ class TestDeepARUtils(unittest.TestCase):
         expected_df.loc[[3, 4], target_col] = float('nan')
         expected_df = expected_df.set_index(time_col).rename_axis(None)
         expected_df = expected_df.to_period("M")
+
+        # Assert equality
+        pd.testing.assert_frame_equal(transformed_df, expected_df)
+
+    @parameterized.expand([(1,), (5,), (10,), (15,), (30,)])
+    def test_single_series_with_multiple_minute_index(self, frequency_quantity):
+        target_col = "sales"
+        time_col = "date"
+        num_rows = 6
+
+        base_dates = pd.date_range(start="2020-10-01", periods=num_rows, freq=f"{frequency_quantity}min")
+
+        base_df = pd.DataFrame({
+            time_col: base_dates,
+            target_col: range(num_rows)
+        })
+
+        # Create a dataframe with missing months (drop the 3rd and 4th rows)
+        dropped_df = base_df.drop([3, 4]).reset_index(drop=True)
+
+        # Transform the dataframe
+        transformed_df = set_index_and_fill_missing_time_steps(
+            dropped_df,
+            time_col,
+            "min",
+            frequency_quantity
+        )
+
+        # Create expected dataframe
+        expected_df = base_df.copy()
+        expected_df.loc[[3, 4], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None).asfreq(f"{frequency_quantity}min")
 
         # Assert equality
         pd.testing.assert_frame_equal(transformed_df, expected_df)

--- a/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/deepar/utils_test.py
@@ -143,3 +143,112 @@ class TestDeepARUtils(unittest.TestCase):
 
         # Assert equality
         pd.testing.assert_frame_equal(transformed_df, expected_df)
+
+    def test_single_series_month_start_index(self):
+        target_col = "sales"
+        time_col = "date"
+        num_months = 24
+
+        # Starting from first day of January 2020
+        base_dates = pd.date_range(
+            start='2020-01-01',
+            periods=num_months,
+            freq='MS'
+        )
+
+        base_df = pd.DataFrame({
+            time_col: base_dates,
+            target_col: range(num_months)
+        })
+
+        # Create a dataframe with missing months (drop months 3 and 4)
+        dropped_df = base_df.drop([3, 4]).reset_index(drop=True)
+
+        # Transform the dataframe
+        transformed_df = set_index_and_fill_missing_time_steps(
+            dropped_df,
+            time_col,
+            "MS" # Monthly frequency
+        )
+
+        # Create expected dataframe
+        expected_df = base_df.copy()
+        expected_df.loc[[3, 4], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None)
+        expected_df = expected_df.to_period("M")
+
+        # Assert equality
+        pd.testing.assert_frame_equal(transformed_df, expected_df)
+
+    def test_single_series_month_mid_index(self):
+        target_col = "sales"
+        time_col = "date"
+        num_months = 24
+
+        # Starting from fifteenth day of January 2020
+        base_dates = pd.date_range(
+            start='2020-01-01',
+            periods=num_months,
+            freq='MS'  
+        ) + pd.DateOffset(days=14)
+
+        base_df = pd.DataFrame({
+            time_col: base_dates,
+            target_col: range(num_months)
+        })
+
+        # Create a dataframe with missing months (drop months 3 and 4)
+        dropped_df = base_df.drop([3, 4]).reset_index(drop=True)
+
+        # Transform the dataframe
+        transformed_df = set_index_and_fill_missing_time_steps(
+            dropped_df,
+            time_col,
+            "MS"
+        )
+
+        # Create expected dataframe
+        expected_df = base_df.copy()
+        expected_df.loc[[3, 4], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None)
+        expected_df = expected_df.to_period("M")
+
+        # Assert equality
+        pd.testing.assert_frame_equal(transformed_df, expected_df)
+
+    def test_single_series_month_end_index(self):
+        target_col = "sales"
+        time_col = "date"
+        num_months = 24
+
+        # Starting from end day of January 2020
+        # by specifying freq='M', it is by default the end of the month
+        base_dates = pd.date_range(
+            start='2020-01-01',
+            periods=num_months,
+            freq='M'  
+        )
+
+        base_df = pd.DataFrame({
+            time_col: base_dates,
+            target_col: range(num_months)
+        })
+
+        # Create a dataframe with missing months (drop months 3 and 4)
+        dropped_df = base_df.drop([3, 4]).reset_index(drop=True)
+
+        # Transform the dataframe
+        transformed_df = set_index_and_fill_missing_time_steps(
+            dropped_df,
+            time_col,
+            "MS" # Monthly frequency
+        )
+
+        # Create expected dataframe
+        expected_df = base_df.copy()
+        expected_df.loc[[3, 4], target_col] = float('nan')
+        expected_df = expected_df.set_index(time_col).rename_axis(None)
+        expected_df = expected_df.to_period("M")
+
+        # Assert equality
+        pd.testing.assert_frame_equal(transformed_df, expected_df)

--- a/runtime/tests/automl_runtime/forecast/pmdarima/diagnostics_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/diagnostics_test.py
@@ -43,7 +43,7 @@ class TestDiagnostics(unittest.TestCase):
         (df_with_exogenous, ["x1", "x2"])
     ])
     def test_cross_validation_success(self, df, exogenous_cols):
-        cutoffs = generate_cutoffs(df, horizon=3, unit="D", seasonal_period=1, seasonal_unit="D", num_folds=3)
+        cutoffs = generate_cutoffs(df, horizon=3, frequency_unit="D", seasonal_period=1, seasonal_unit="D", num_folds=3)
         train_df = df[df["ds"] <= cutoffs[0]].set_index("ds")
         y_train = train_df[["y"]]
         X_train = train_df.drop(["y"], axis=1)

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -41,7 +41,8 @@ class TestArimaModel(unittest.TestCase):
         self.start_ds = pd.Timestamp("2020-10-01")
         self.horizon = 1
         self.freq = 'W'
-        dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency=self.freq)
+        self.frequency_quantity=1
+        dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency_unit=self.freq, frequency_quantity=self.frequency_quantity)
         self.df = pd.concat([
             pd.Series(dates, name='date'),
             pd.Series(range(self.num_rows), name="y")
@@ -51,7 +52,8 @@ class TestArimaModel(unittest.TestCase):
         pickled_model = pickle.dumps(model)
         self.arima_model = ArimaModel(pickled_model,
                                       horizon=self.horizon,
-                                      frequency=self.freq,
+                                      frequency_unit=self.freq,
+                                      frequency_quantity=self.frequency_quantity,
                                       start_ds=self.start_ds,
                                       end_ds=pd.Timestamp("2020-11-26"),
                                       time_col="date")
@@ -67,7 +69,8 @@ class TestArimaModel(unittest.TestCase):
         expected_ds = AbstractArimaModel._get_ds_indices(
             self.start_ds,
             periods=self.num_rows + self.horizon,
-            frequency=self.freq)
+            frequency_unit=self.freq,
+            frequency_quantity=self.frequency_quantity)
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
         self.assertEqual(10, forecast_pd.shape[0])
         pd.testing.assert_series_equal(pd.Series(expected_ds, name='ds'), forecast_pd["ds"])
@@ -135,8 +138,9 @@ class TestArimaModelDate(unittest.TestCase):
         self.start_ds = datetime.date(2020, 10, 1)
         self.horizon = 1
         self.freq = 'W'
+        self.frequency_quantity = 1
         dates = AbstractArimaModel._get_ds_indices(
-            pd.to_datetime(self.start_ds), periods=self.num_rows, frequency=self.freq)
+            pd.to_datetime(self.start_ds), periods=self.num_rows, frequency_unit=self.freq, frequency_quantity=self.frequency_quantity)
         self.df = pd.concat([
             pd.Series(dates, name='date'),
             pd.Series(range(self.num_rows), name="y")
@@ -146,7 +150,8 @@ class TestArimaModelDate(unittest.TestCase):
         pickled_model = pickle.dumps(model)
         self.arima_model = ArimaModel(pickled_model,
                                       horizon=self.horizon,
-                                      frequency=self.freq,
+                                      frequency_unit=self.freq,
+                                      frequency_quantity=self.frequency_quantity,
                                       start_ds=self.start_ds,
                                       end_ds=pd.Timestamp("2020-11-26"),
                                       time_col="date")
@@ -168,7 +173,8 @@ class TestArimaModelWithExogenous(unittest.TestCase):
         self.start_ds = pd.Timestamp("2020-10-01")
         self.horizon = 1
         self.freq = 'W'
-        dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency=self.freq)
+        self.frequency_quantity = 1
+        dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency_unit=self.freq, frequency_quantity=self.frequency_quantity)
         self.df = pd.concat([
             pd.Series(dates, name='date'),
             pd.Series(range(self.num_rows), name="y"),
@@ -183,7 +189,8 @@ class TestArimaModelWithExogenous(unittest.TestCase):
         pickled_model = pickle.dumps(model)
         self.arima_model = ArimaModel(pickled_model,
                                       horizon=self.horizon,
-                                      frequency=self.freq,
+                                      frequency_unit=self.freq,
+                                      frequency_quantity=self.frequency_quantity,
                                       start_ds=self.start_ds,
                                       end_ds=pd.Timestamp("2020-11-26"),
                                       time_col="date",
@@ -227,7 +234,8 @@ class TestMultiSeriesArimaModel(unittest.TestCase):
         end_ds_dict = {("1",): pd.Timestamp("2020-09-13"), ("2",): pd.Timestamp("2020-09-13")}
         self.arima_model = MultiSeriesArimaModel(pickled_model_dict,
                                                  horizon=1,
-                                                 frequency='month',
+                                                 frequency_unit='month',
+                                                 frequency_quantity=1,
                                                  start_ds_dict=start_ds_dict,
                                                  end_ds_dict=end_ds_dict,
                                                  time_col="date",
@@ -310,7 +318,8 @@ class TestMultiSeriesArimaModel(unittest.TestCase):
         end_ds_dict = {(1, "1"): pd.Timestamp("2020-09-13"), (2, "1"): pd.Timestamp("2020-09-13")}
         arima_model = MultiSeriesArimaModel(pickled_model_dict,
                                             horizon=1,
-                                            frequency='month',
+                                            frequency_unit='month',
+                                            frequency_quantity=1,
                                             start_ds_dict=start_ds_dict,
                                             end_ds_dict=end_ds_dict,
                                             time_col="date",
@@ -350,7 +359,8 @@ class TestMultiSeriesArimaModelWithExogenous(unittest.TestCase):
         end_ds_dict = {("1",): pd.Timestamp("2020-09-13"), ("2",): pd.Timestamp("2020-09-13")}
         self.arima_model = MultiSeriesArimaModel(pickled_model_dict,
                                                  horizon=1,
-                                                 frequency='month',
+                                                 frequency_unit='month',
+                                                 frequency_quantity=1,
                                                  start_ds_dict=start_ds_dict,
                                                  end_ds_dict=end_ds_dict,
                                                  time_col="date",
@@ -404,7 +414,8 @@ class TestAbstractArimaModel(unittest.TestCase):
         ds_indices = AbstractArimaModel._get_ds_indices(
             start_ds=pd.Timestamp("2022-01-01 12:30"),
             periods=8,
-            frequency='W')
+            frequency_unit='W',
+            frequency_quantity=1)
         pd.testing.assert_index_equal(expected_ds, ds_indices)
 
     def test_get_ds_hourly(self):
@@ -418,7 +429,8 @@ class TestAbstractArimaModel(unittest.TestCase):
         ds_indices = AbstractArimaModel._get_ds_indices(
             start_ds=pd.Timestamp("2021-12-10 09:23"),
             periods=10,
-            frequency='H')
+            frequency_unit='H',
+            frequency_quantity=1)
         pd.testing.assert_index_equal(expected_ds, ds_indices)
 
 
@@ -435,7 +447,7 @@ class TestLogModel(unittest.TestCase):
         self.pickled_model = pickle.dumps(model)
 
     def test_mlflow_arima_log_model(self):
-        arima_model = ArimaModel(self.pickled_model, horizon=1, frequency='d',
+        arima_model = ArimaModel(self.pickled_model, horizon=1, frequency_unit='d', frequency_quantity=1,
                                  start_ds=pd.to_datetime("2020-10-01"), end_ds=pd.to_datetime("2020-10-09"),
                                  time_col="date")
         with mlflow.start_run() as run:
@@ -460,7 +472,8 @@ class TestLogModel(unittest.TestCase):
         end_ds_dict = {("1",): pd.Timestamp("2020-10-09"), ("2",): pd.Timestamp("2020-10-09")}
         multiseries_arima_model = MultiSeriesArimaModel(pickled_model_dict,
                                                         horizon=1,
-                                                        frequency='d',
+                                                        frequency_unit='d',
+                                                        frequency_quantity=1,
                                                         start_ds_dict=start_ds_dict,
                                                         end_ds_dict=end_ds_dict,
                                                         time_col="date",
@@ -497,3 +510,112 @@ class TestLogModel(unittest.TestCase):
         # check if all additional dependencies are logged
         for dependency in ARIMA_ADDITIONAL_PIP_DEPS:
             self.assertIn(dependency, requirements, f"requirements.txt should contain {dependency} but got {requirements}")
+
+class TestArimaModelFrequencyQuantity(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.num_rows = 9
+        self.start_ds = pd.Timestamp("2020-10-01")
+        self.horizon = 1
+        self.freq = 'min'
+        frequency_quantities = [1, 5, 10, 15, 30]
+        self.quantity_model_pairs = []
+
+        for frequency_quantity in frequency_quantities:
+            dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency_unit=self.freq, frequency_quantity=frequency_quantity)
+            df = pd.concat([
+                pd.Series(dates, name='date'),
+                pd.Series(range(self.num_rows), name="y")
+            ], axis=1)
+            model = ARIMA(order=(2, 0, 2), suppress_warnings=True)
+            model.fit(df.set_index("date"))
+            pickled_model = pickle.dumps(model)
+            self.quantity_model_pairs.append((frequency_quantity, ArimaModel(pickled_model,
+                                      horizon=self.horizon,
+                                      frequency_unit=self.freq,
+                                      frequency_quantity=frequency_quantity,
+                                      start_ds=self.start_ds,
+                                      end_ds=dates.max(),
+                                      time_col="date")))
+
+    def test_make_future_dataframe(self):
+        for frequency_quantity, arima_model in self.quantity_model_pairs:
+            future_df = arima_model.make_future_dataframe(include_history=False)
+            self.assertCountEqual(future_df.columns, {"ds"})
+            self.assertEqual(1, future_df.shape[0])
+
+    def test_predict_timeseries_success(self):
+        for frequency_quantity, arima_model in self.quantity_model_pairs:
+            forecast_pd = arima_model.predict_timeseries()
+            expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
+            expected_ds = AbstractArimaModel._get_ds_indices(
+                self.start_ds,
+                periods=self.num_rows + self.horizon,
+                frequency_unit=self.freq,
+                frequency_quantity=frequency_quantity)
+            self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
+            self.assertEqual(10, forecast_pd.shape[0])
+            pd.testing.assert_series_equal(pd.Series(expected_ds, name='ds'), forecast_pd["ds"])
+            # Test forecast without history data
+            forecast_future_pd = arima_model.predict_timeseries(include_history=False)
+            self.assertEqual(len(forecast_future_pd), self.horizon)
+
+    def test_predict_success(self):
+        for frequency_quantity, arima_model in self.quantity_model_pairs:
+            test_df = pd.DataFrame({
+                "date": [pd.to_datetime("2020-10-01") + self.num_rows*pd.DateOffset(minutes=frequency_quantity), 
+                         pd.to_datetime("2020-10-01") + (self.num_rows+1)*pd.DateOffset(minutes=frequency_quantity)]
+            })
+            expected_test_df = test_df.copy()
+            yhat = arima_model.predict(context=None, model_input=test_df)
+            self.assertEqual(2, len(yhat))
+            pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
+
+    def test_predict_success_datetime_date(self):
+        for _, arima_model in self.quantity_model_pairs:
+            test_df = pd.DataFrame({
+                "date": [datetime.datetime(2020, 10, 1, 6, 0, 0), datetime.datetime(2020, 10, 1, 6, 30, 0)]
+            })
+            expected_test_df = test_df.copy()
+            yhat = arima_model.predict(context=None, model_input=test_df)
+            self.assertEqual(2, len(yhat))
+            pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
+
+    def test_predict_success_string(self):
+        for _, arima_model in self.quantity_model_pairs:
+            test_df = pd.DataFrame({
+                "date": ["2020-10-01 06:00:00", "2020-10-01 06:30:00"]
+            })
+            expected_test_df = test_df.copy()
+            yhat = arima_model.predict(context=None, model_input=test_df)
+            self.assertEqual(2, len(yhat))
+            pd.testing.assert_frame_equal(test_df, expected_test_df)  # check the input dataframe is unchanged
+
+    def test_predict_failure_unmatched_frequency(self):
+        for frequency_quantity, arima_model in self.quantity_model_pairs:
+            if frequency_quantity == 1: continue
+            test_df = pd.DataFrame({
+                "date": [pd.to_datetime("2020-10-01 00:00:00"), pd.to_datetime("2020-10-01 00:01:00"), pd.to_datetime("2020-10-01 00:04:00")]
+            })
+            with pytest.raises(MlflowException, match="includes different frequency") as e:
+                arima_model.predict(context=None, model_input=test_df)
+            assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+    def test_predict_failure_invalid_time_range(self):
+        for _, arima_model in self.quantity_model_pairs:
+            test_df = pd.DataFrame({
+                "date": [pd.to_datetime("2020-09-30 00:00:00"), pd.to_datetime("2020-10-01 00:01:00")]
+            })
+            with pytest.raises(MlflowException, match="includes time earlier than the history data that the model was "
+                                                    "trained on") as e:
+                arima_model.predict(context=None, model_input=test_df)
+            assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+    def test_predict_failure_invalid_time_col_name(self):
+        for _, arima_model in self.quantity_model_pairs:
+            test_df = pd.DataFrame({
+                "invalid_time_col_name": [pd.to_datetime("2020-10-08"), pd.to_datetime("2020-12-10")]
+            })
+            with pytest.raises(MlflowException, match="Input data columns") as e:
+                arima_model.predict(context=None, model_input=test_df)
+            assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/model_test.py
@@ -17,6 +17,7 @@
 import unittest
 import pickle
 import datetime
+from unittest import mock
 
 import mlflow
 import pytest
@@ -197,13 +198,13 @@ class TestArimaModelWithExogenous(unittest.TestCase):
                                       exogenous_cols=self.exogenous_cols)
 
     def test_predict_timeseries_success(self):
-        forecast_pd = self.arima_model.predict_timeseries(df=self.df)
+        forecast_pd = self.arima_model.predict_timeseries(future_df=self.df)
         expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
         self.assertEqual(10, forecast_pd.shape[0])
         pd.testing.assert_series_equal(self.df["date"], forecast_pd["ds"], check_names=False)
         # Test forecast without history data
-        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, df=self.df)
+        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, future_df=self.df)
         self.assertEqual(len(forecast_future_pd), self.horizon)
 
     def test_predict_success(self):
@@ -345,7 +346,8 @@ class TestMultiSeriesArimaModelWithExogenous(unittest.TestCase):
             pd.to_datetime(pd.Series(range(num_rows), name="date").apply(lambda i: f"2020-{i + 1:02d}-13")),
             pd.Series(range(num_rows), name="y"),
             pd.Series(range(num_rows), name="x1"),
-            pd.Series(range(num_rows), name="x2")
+            pd.Series(range(num_rows), name="x2"),
+            pd.Series(["1" if i < 5 else "2" for i in range(num_rows)], name="id")  # Add id column with different values
         ], axis=1)
         train_df = self.df.set_index("date")
         self.exogenous_cols = ["x1", "x2"]
@@ -368,12 +370,12 @@ class TestMultiSeriesArimaModelWithExogenous(unittest.TestCase):
                                                  exogenous_cols=self.exogenous_cols)
 
     def test_predict_timeseries_success(self):
-        forecast_pd = self.arima_model.predict_timeseries(df=self.df)
+        forecast_pd = self.arima_model.predict_timeseries(future_df=self.df)
         expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
         self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
         self.assertEqual(18, forecast_pd.shape[0])
         # Test forecast without history data
-        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, df=self.df)
+        forecast_future_pd = self.arima_model.predict_timeseries(include_history=False, future_df=self.df)
         self.assertEqual(len(forecast_future_pd), 2)
 
     def test_predict_success(self):
@@ -619,3 +621,167 @@ class TestArimaModelFrequencyQuantity(unittest.TestCase):
             with pytest.raises(MlflowException, match="Input data columns") as e:
                 arima_model.predict(context=None, model_input=test_df)
             assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+class TestArimaModelWithPreprocess(unittest.TestCase):
+    def setUp(self) -> None:
+        self.num_rows = 9
+        self.start_ds = pd.Timestamp("2020-10-01")
+        self.horizon = 1
+        self.freq = 'W'
+        self.frequency_quantity = 1
+        dates = AbstractArimaModel._get_ds_indices(self.start_ds, periods=self.num_rows, frequency_unit=self.freq, frequency_quantity=self.frequency_quantity)
+        self.df = pd.concat([
+            pd.Series(dates, name='date'),
+            pd.Series(range(self.num_rows), name="y"),
+            pd.Series(range(self.num_rows), name="x1"),
+            pd.Series(range(self.num_rows), name="x2")
+        ], axis=1)
+        model = ARIMA(order=(2, 0, 2), suppress_warnings=True)
+        model.fit(self.df[["y", "date"]].set_index("date"), exogenous=self.df[["x1", "x2"]])
+        pickled_model = pickle.dumps(model)
+
+        # Create a mock preprocess function that doubles y values
+        def preprocess_func(df):
+            df = df.copy()
+            df["y"] = df["y"] * 2
+            return df
+        
+        self.mock_preprocess = mock.Mock(side_effect=preprocess_func)
+
+        self.arima_model = ArimaModel(pickled_model,
+                                     horizon=self.horizon,
+                                     frequency_unit=self.freq,
+                                     frequency_quantity=self.frequency_quantity,
+                                     start_ds=self.start_ds,
+                                     end_ds=pd.Timestamp("2020-11-26"),
+                                     time_col="date",
+                                     exogenous_cols=["x1", "x2"],
+                                     split_col="split",
+                                     preprocess_func=self.mock_preprocess)
+
+    def test_predict_timeseries_with_preprocess(self):
+        future_df = self.df.copy()
+        future_df = pd.concat([future_df, pd.DataFrame({
+            "date": [pd.to_datetime("2020-12-17"), pd.to_datetime("2020-12-24")],
+            "x1": [1, 2],
+            "x2": [3, 4]
+        })], axis=0)
+        future_df["split"] = "prediction"
+        
+        forecast_pd = self.arima_model.predict_timeseries(future_df=future_df)
+        expected_columns = {"yhat", "yhat_lower", "yhat_upper"}
+        self.assertTrue(expected_columns.issubset(set(forecast_pd.columns)))
+        self.assertEqual(11, forecast_pd.shape[0])
+        
+        # Verify that preprocess_func was called with the correct argument
+        self.mock_preprocess.assert_called_once()
+        call_arg = self.mock_preprocess.call_args[0][0]
+        
+        # Verify the structure of the dataframe passed to preprocess_func
+        expected_call = future_df.copy()
+        expected_call["y"] = None
+        expected_call["split"] = "prediction"
+        pd.testing.assert_frame_equal(call_arg, expected_call)
+        
+        # Verify the return value from preprocess_func
+        # The preprocess function doubles y values
+        expected_return = expected_call.copy()
+        expected_return["y"] = expected_return["y"] * 2 if expected_return["y"] is not None else 0
+        
+        # Get the actual return value from the call
+        actual_return = self.mock_preprocess.side_effect(call_arg)
+        pd.testing.assert_frame_equal(actual_return, expected_return)
+
+    def test_predict_with_preprocess(self):
+        test_df = pd.DataFrame({
+            "date": [pd.to_datetime("2020-12-17"), pd.to_datetime("2020-12-24")],
+            "x1": [1, 2],
+            "x2": [3, 4]
+        })
+        
+        yhat = self.arima_model.predict(context=None, model_input=test_df)
+        self.assertEqual(2, len(yhat))
+        
+        # Verify that preprocess_func was called with the correct argument
+        self.mock_preprocess.assert_called_once()
+        call_arg = self.mock_preprocess.call_args[0][0]
+        
+        # Verify the structure of the dataframe passed to preprocess_func
+        expected_call = test_df.copy()
+        expected_call["y"] = None
+        expected_call["split"] = "prediction"
+        pd.testing.assert_frame_equal(call_arg, expected_call)
+        
+        # Verify the return value from preprocess_func
+        # The preprocess function doubles y values
+        expected_return = expected_call.copy()
+        expected_return["y"] = expected_return["y"] * 2 if expected_return["y"] is not None else 0
+        
+        # Get the actual return value from the call
+        actual_return = self.mock_preprocess.side_effect(call_arg)
+        pd.testing.assert_frame_equal(actual_return, expected_return)
+
+class TestMultiSeriesArimaModelWithPreprocess(unittest.TestCase):
+    def setUp(self) -> None:
+        num_rows = 9
+        self.df = pd.concat([
+            pd.to_datetime(pd.Series(range(num_rows), name="date").apply(lambda i: f"2020-{i + 1:02d}-13")),
+            pd.Series(range(num_rows), name="y")
+        ], axis=1)
+        model = ARIMA(order=(2, 0, 2), suppress_warnings=True)
+        model.fit(self.df.set_index("date"))
+        self.pickled_model = pickle.dumps(model)
+        pickled_model_dict = {("1",): self.pickled_model, ("2",): self.pickled_model}
+        start_ds_dict = {("1",): pd.Timestamp("2020-01-13"), ("2",): pd.Timestamp("2020-01-13")}
+        end_ds_dict = {("1",): pd.Timestamp("2020-09-13"), ("2",): pd.Timestamp("2020-09-13")}
+
+        # Create a mock preprocess function that adds 1 to y values
+        def preprocess_func(df):
+            df = df.copy()
+            df["y"] = df["y"] + 1
+            return df
+        
+        self.mock_preprocess = mock.Mock(side_effect=preprocess_func)
+
+        self.arima_model = MultiSeriesArimaModel(pickled_model_dict,
+                                                horizon=1,
+                                                frequency_unit='month',
+                                                frequency_quantity=1,
+                                                start_ds_dict=start_ds_dict,
+                                                end_ds_dict=end_ds_dict,
+                                                time_col="date",
+                                                id_cols=["id"],
+                                                split_col="split",
+                                                preprocess_func=self.mock_preprocess)
+
+    def test_predict_with_preprocess(self):
+        test_df = pd.DataFrame({
+            "date": [pd.to_datetime("2020-05-13"), pd.to_datetime("2020-05-13"),
+                     pd.to_datetime("2020-12-13"), pd.to_datetime("2020-12-13")],
+            "id": ["1", "2", "1", "2"]
+        })
+        
+        yhat = self.arima_model.predict(context=None, model_input=test_df)
+        self.assertEqual(4, len(yhat))
+        
+        # Verify that preprocess_func was called three times:
+        # 1. In predict() for the entire dataframe
+        # 2. For each time series (id=1 and id=2)
+        self.assertEqual(len(self.mock_preprocess.call_args_list), 3)
+        
+        # First call: entire dataframe
+        first_call_arg = self.mock_preprocess.call_args_list[0][0][0]
+        expected_first_call = test_df.copy()
+        expected_first_call["ts_id"] = expected_first_call[["id"]].apply(tuple, axis=1)
+        expected_first_call["y"] = None
+        expected_first_call["split"] = "prediction"
+        pd.testing.assert_frame_equal(first_call_arg, expected_first_call)
+        
+        # Verify the return value from preprocess_func
+        # The preprocess function adds 1 to y values
+        expected_return = expected_first_call.copy()
+        expected_return["y"] = expected_return["y"] + 1 if expected_return["y"] is not None else 1
+        
+        # Get the actual return value from the first call
+        actual_return = self.mock_preprocess.side_effect(first_call_arg)
+        pd.testing.assert_frame_equal(actual_return, expected_return)

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -72,6 +72,20 @@ class TestArimaEstimator(unittest.TestCase):
         results_pd = arima_estimator.fit(self.df_with_exogenous)
         self.assertIn("smape", results_pd)
         self.assertIn("pickled_model", results_pd)
+    
+    def test_fit_success_with_split_cutoff(self):
+        for freq, df, split_cutoff in [['d', self.df, '2020-07-17 00:00:00'], 
+                         ['d', self.df_string_time, '2020-07-17 00:00:00'], 
+                         ['month', self.df_monthly, '2020-09-07 00:00:00']]:
+            arima_estimator = ArimaEstimator(horizon=1,
+                                            frequency_unit=freq,
+                                            metric="smape",
+                                            seasonal_periods=[1, 7],
+                                            num_folds=2,
+                                            split_cutoff=pd.Timestamp(split_cutoff))
+            results_pd = arima_estimator.fit(df)
+            self.assertIn("smape", results_pd)
+            self.assertIn("pickled_model", results_pd)
 
     def test_fit_skip_too_long_seasonality(self):
         arima_estimator = ArimaEstimator(horizon=1,

--- a/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
+++ b/runtime/tests/automl_runtime/forecast/pmdarima/training_test.py
@@ -48,13 +48,37 @@ class TestArimaEstimator(unittest.TestCase):
             pd.Series(np.random.rand(self.num_rows), name="x1"),
             pd.Series(np.random.rand(self.num_rows), name="x2")
         ], axis=1)
+        self.df_with_5_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="5min"), name="ds"),
+            pd.Series(np.random.rand(self.num_rows), name="y"),
+        ], axis=1)
+        self.df_with_10_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="10min"), name="ds"),
+            pd.Series(np.random.rand(self.num_rows), name="y"),
+        ], axis=1)
+        self.df_with_15_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="15min"), name="ds"),
+            pd.Series(np.random.rand(self.num_rows), name="y"),
+        ], axis=1)
+        self.df_with_30_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="30min"), name="ds"),
+            pd.Series(np.random.rand(self.num_rows), name="y"),
+        ], axis=1)
 
     def test_fit_success(self):
-        for freq, df in [['d', self.df], ['d', self.df_string_time], ['month', self.df_monthly]]:
+        for freq, frequancy_quantity, df, seasonal_periods in [
+            ['d', 1, self.df, [1, 7]], 
+            ['d', 1, self.df_string_time, [1, 7]], 
+            ['month', 1, self.df_monthly, [1, 12]],
+            ['min', 5, self.df_with_5_minute_interval, [1]],
+            ['min', 10, self.df_with_10_minute_interval, [1]],
+            ['min', 15, self.df_with_15_minute_interval, [1]],
+            ['min', 30, self.df_with_30_minute_interval, [1]]]:
             arima_estimator = ArimaEstimator(horizon=1,
                                              frequency_unit=freq,
+                                             frequency_quantity=frequancy_quantity,
                                              metric="smape",
-                                             seasonal_periods=[1, 7],
+                                             seasonal_periods=seasonal_periods,
                                              num_folds=2)
 
             results_pd = arima_estimator.fit(df)
@@ -64,6 +88,7 @@ class TestArimaEstimator(unittest.TestCase):
     def test_fit_success_with_exogenous(self):
         arima_estimator = ArimaEstimator(horizon=1,
                                          frequency_unit="d",
+                                         frequency_quantity=1,
                                          metric="smape",
                                          seasonal_periods=[1, 7],
                                          num_folds=2,
@@ -74,11 +99,16 @@ class TestArimaEstimator(unittest.TestCase):
         self.assertIn("pickled_model", results_pd)
     
     def test_fit_success_with_split_cutoff(self):
-        for freq, df, split_cutoff in [['d', self.df, '2020-07-17 00:00:00'], 
-                         ['d', self.df_string_time, '2020-07-17 00:00:00'], 
-                         ['month', self.df_monthly, '2020-09-07 00:00:00']]:
+        for freq, frequency_quantity, df, split_cutoff in [['d', 1, self.df, '2020-07-17 00:00:00'], 
+                         ['d', 1, self.df_string_time, '2020-07-17 00:00:00'], 
+                         ['month', 1, self.df_monthly, '2020-09-07 00:00:00'],
+                         ['min', 5, self.df_with_5_minute_interval, '2020-07-05 00:30:00'],
+                         ['min', 10, self.df_with_10_minute_interval, '2020-07-05 01:00:00'],
+                         ['min', 15, self.df_with_15_minute_interval, '2020-07-05 01:30:00'],
+                         ['min', 30, self.df_with_30_minute_interval, '2020-07-05 03:00:00']]:
             arima_estimator = ArimaEstimator(horizon=1,
                                             frequency_unit=freq,
+                                            frequency_quantity=frequency_quantity,
                                             metric="smape",
                                             seasonal_periods=[1, 7],
                                             num_folds=2,
@@ -90,18 +120,20 @@ class TestArimaEstimator(unittest.TestCase):
     def test_fit_skip_too_long_seasonality(self):
         arima_estimator = ArimaEstimator(horizon=1,
                                          frequency_unit="d",
+                                         frequency_quantity=1,
                                          metric="smape",
                                          seasonal_periods=[3, 14],
                                          num_folds=2)
         with self.assertLogs(logger="databricks.automl_runtime.forecast.pmdarima.training", level="WARNING") as cm:
             results_pd = arima_estimator.fit(self.df)
-            self.assertIn("Skipping seasonal_period=14 (D). Dataframe timestamps must span at least two seasonality periods", cm.output[0])
+            self.assertIn("Skipping seasonal_period=14 (1D). Dataframe timestamps must span at least two seasonality periods", cm.output[0])
 
     @patch("databricks.automl_runtime.forecast.prophet.forecast.utils.generate_cutoffs")
     def test_fit_horizon_truncation(self, mock_generate_cutoffs):
         period = 2
         arima_estimator = ArimaEstimator(horizon=100,
                                          frequency_unit="d",
+                                         frequency_quantity=1,
                                          metric="smape",
                                          seasonal_periods=[period],
                                          num_folds=2)
@@ -119,6 +151,7 @@ class TestArimaEstimator(unittest.TestCase):
         period = 2
         arima_estimator = ArimaEstimator(horizon=100,
                                          frequency_unit="d",
+                                         frequency_quantity=1,
                                          metric="smape",
                                          seasonal_periods=[period],
                                          num_folds=2)
@@ -137,6 +170,7 @@ class TestArimaEstimator(unittest.TestCase):
         # The fit method still succeeds because m=1 succeeds
         arima_estimator = ArimaEstimator(horizon=1,
                                          frequency_unit="d",
+                                         frequency_quantity=1,
                                          metric="smape",
                                          seasonal_periods=[1, 7, 30],
                                          num_folds=2)
@@ -147,6 +181,7 @@ class TestArimaEstimator(unittest.TestCase):
     def test_fit_failure_inconsistent_frequency(self):
         arima_estimator = ArimaEstimator(horizon=1,
                                          frequency_unit="W",
+                                         frequency_quantity=1,
                                          metric="smape",
                                          seasonal_periods=[1],
                                          num_folds=2)
@@ -156,6 +191,7 @@ class TestArimaEstimator(unittest.TestCase):
     def test_fit_failure_no_succeeded_model(self):
         arima_estimator = ArimaEstimator(horizon=1,
                                          frequency_unit="d",
+                                         frequency_quantity=1,
                                          metric="smape",
                                          seasonal_periods=[30],
                                          num_folds=2)
@@ -182,7 +218,7 @@ class TestArimaEstimator(unittest.TestCase):
             )
             indices_to_drop = [5, 8]
             df_missing = pd.DataFrame({"ds": ds, "y": range(12)}).drop(indices_to_drop).reset_index(drop=True)
-            df_filled = ArimaEstimator._fill_missing_time_steps(df_missing, frequency=frequency)
+            df_filled = ArimaEstimator._fill_missing_time_steps(df_missing, frequency_unit=frequency, frequency_quantity=1)
             for index in indices_to_drop:
                 self.assertTrue(df_filled["y"][index] == df_filled["y"][index - 1])
             self.assertEqual(ds.to_list(), df_filled["ds"].to_list())
@@ -196,16 +232,35 @@ class TestArimaEstimator(unittest.TestCase):
             )
             indices_to_drop = [5, 8]
             df_missing = pd.DataFrame({"ds": ds, "y": range(12), "x": range(12)}).drop(indices_to_drop).reset_index(drop=True)
-            df_filled = ArimaEstimator._fill_missing_time_steps(df_missing, frequency=frequency)
+            df_filled = ArimaEstimator._fill_missing_time_steps(df_missing, frequency_unit=frequency, frequency_quantity=1)
             for index in indices_to_drop:
                 self.assertTrue(df_filled["y"][index] == df_filled["y"][index - 1])
                 self.assertTrue(df_filled["x"][index] == df_filled["x"][index - 1])
             self.assertEqual(ds.to_list(), df_filled["ds"].to_list())
 
+    def test_fill_missing_time_steps_with_multiple_frequency_quantities(self):
+        supported_quantities = [1, 5, 10, 15, 30]
+        start_ds = pd.Timestamp("2020-07-05 00:00:00")
+        for quantity in supported_quantities:
+            ds = pd.date_range(start=start_ds, periods=12, freq=pd.DateOffset(**{'minutes': quantity}))
+            indices_to_drop = [5, 8]
+            df_missing = pd.DataFrame({"ds": ds, "y": range(12)}).drop(indices_to_drop).reset_index(drop=True)
+            df_filled = ArimaEstimator._fill_missing_time_steps(df_missing, frequency_unit='min', frequency_quantity=quantity)
+            for index in indices_to_drop:
+                self.assertTrue(df_filled["y"][index] == df_filled["y"][index - 1])
+            self.assertEqual(ds.to_list(), df_filled["ds"].to_list())
+
     def test_validate_ds_freq_matched_frequency(self):
-        ArimaEstimator._validate_ds_freq(self.df, frequency='D')
-        ArimaEstimator._validate_ds_freq(self.df_monthly, frequency='month')
+        ArimaEstimator._validate_ds_freq(self.df, frequency_unit='D', frequency_quantity=1)
+        ArimaEstimator._validate_ds_freq(self.df_monthly, frequency_unit='month', frequency_quantity=1)
+        ArimaEstimator._validate_ds_freq(self.df_with_5_minute_interval, frequency_unit='min', frequency_quantity=5)
+        ArimaEstimator._validate_ds_freq(self.df_with_10_minute_interval, frequency_unit='min', frequency_quantity=10)
+        ArimaEstimator._validate_ds_freq(self.df_with_15_minute_interval, frequency_unit='min', frequency_quantity=15)
+        ArimaEstimator._validate_ds_freq(self.df_with_30_minute_interval, frequency_unit='min', frequency_quantity=30)
 
     def test_validate_ds_freq_unmatched_frequency(self):
         with pytest.raises(ValueError, match="includes different frequency"):
-            ArimaEstimator._validate_ds_freq(self.df, frequency='W')
+            ArimaEstimator._validate_ds_freq(self.df, frequency_unit='W', frequency_quantity=1)
+        
+        with pytest.raises(ValueError, match="includes different frequency"):
+            ArimaEstimator._validate_ds_freq(self.df_with_5_minute_interval, frequency_unit='min', frequency_quantity=10)

--- a/runtime/tests/automl_runtime/forecast/prophet/diagnostics_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/diagnostics_test.py
@@ -43,7 +43,7 @@ class TestDiagnostics(unittest.TestCase):
         cutoffs = generate_cutoffs(
             self.X,
             horizon=3,
-            unit="MS",
+            frequency_unit="MS",
             seasonal_period=1,
             seasonal_unit="D",
             num_folds=3,

--- a/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/forecast_test.py
@@ -58,6 +58,22 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
             pd.Series(range(self.num_rows), name="ds").apply(lambda i: f"{2012+i:04d}-01-15"),
             y_series
         ], axis=1)
+        self.df_with_5_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="5min"), name="ds"),
+            y_series,
+        ], axis=1)
+        self.df_with_10_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="10min"), name="ds"),
+            y_series,
+        ], axis=1)
+        self.df_with_15_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="15min"), name="ds"),
+            y_series,
+        ], axis=1)
+        self.df_with_30_minute_interval = pd.concat([
+            pd.Series(pd.date_range(start="2020-07-05 00:00:00", periods=self.num_rows, freq="30min"), name="ds"),
+            y_series,
+        ], axis=1)
         self.search_space = {"changepoint_prior_scale": hp.loguniform("changepoint_prior_scale", -2.3, -0.7)}
 
     def test_sequential_training(self):
@@ -96,6 +112,39 @@ class TestProphetHyperoptEstimator(unittest.TestCase):
         for freq, df in [['MS', self.df_string_monthly_time]]:
             hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
                                                     frequency_unit=freq,
+                                                    metric="smape",
+                                                    interval_width=0.8,
+                                                    country_holidays="US",
+                                                    search_space=search_space,
+                                                    num_folds=2,
+                                                    trial_timeout=1000,
+                                                    random_state=0,
+                                                    is_parallel=False)
+            results = hyperopt_estim.fit(df)
+            self.assertAlmostEqual(results["mse"][0], 0, delta=0.0002)
+            self.assertAlmostEqual(results["rmse"][0], 0, delta=0.02)
+            self.assertAlmostEqual(results["mae"][0], 0, delta=0.02)
+            self.assertAlmostEqual(results["mape"][0], 0, delta=0.002)
+            self.assertAlmostEqual(results["mdape"][0], 0, delta=0.002)
+            self.assertAlmostEqual(results["smape"][0], 0, delta=0.002)
+            self.assertGreaterEqual(results["coverage"][0], 0.5)
+            # check the best result parameter is inside the search space
+            model_json = json.loads(results["model_json"][0])
+            self.assertGreaterEqual(model_json["changepoint_prior_scale"], 0.1)
+            self.assertLessEqual(model_json["changepoint_prior_scale"], 0.5)
+    
+    def test_sequential_training_with_multiple_frequency_quantities(self):
+        search_space = {"changepoint_prior_scale": hp.loguniform("changepoint_prior_scale", -2.3, -0.7)}
+        search_space["seasonality_mode"] = hp.choice(
+            'seasonality_mode', ['additive', 'multiplicative']
+        )
+        for df, frequency_quantity, frequency_unit in [[self.df_with_5_minute_interval, 5, "min"], 
+                                                       [self.df_with_10_minute_interval, 10, "min"], 
+                                                       [self.df_with_15_minute_interval, 15, "min"],
+                                                       [self.df_with_30_minute_interval, 30, "min"]]:
+            hyperopt_estim = ProphetHyperoptEstimator(horizon=1,
+                                                    frequency_unit=frequency_unit,
+                                                    frequency_quantity=frequency_quantity,
                                                     metric="smape",
                                                     interval_width=0.8,
                                                     country_holidays="US",

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -32,12 +32,22 @@ from databricks.automl_runtime.forecast.prophet.model import (
     ProphetModel,
     OFFSET_ALIAS_MAP,
     DATE_OFFSET_KEYWORD_MAP,
+    PROPHET_ADDITIONAL_PIP_DEPS
 )
 
 PROPHET_MODEL_JSON = '{"growth": "linear", "n_changepoints": 6, "specified_changepoints": false, "changepoint_range": 0.8, "yearly_seasonality": "auto", "weekly_seasonality": "auto", "daily_seasonality": "auto", "seasonality_mode": "additive", "seasonality_prior_scale": 10.0, "changepoint_prior_scale": 0.05, "holidays_prior_scale": 10.0, "mcmc_samples": 0, "interval_width": 0.8, "uncertainty_samples": 1000, "y_scale": 8.0, "logistic_floor": false, "country_holidays": null, "component_modes": {"additive": ["weekly", "additive_terms", "extra_regressors_additive", "holidays"], "multiplicative": ["multiplicative_terms", "extra_regressors_multiplicative"]}, "changepoints": "{\\"name\\":\\"ds\\",\\"index\\":[1,2,3,4,5,6],\\"data\\":[\\"2020-10-04T00:00:00.000\\",\\"2020-10-07T00:00:00.000\\",\\"2020-10-10T00:00:00.000\\",\\"2020-10-13T00:00:00.000\\",\\"2020-10-16T00:00:00.000\\",\\"2020-10-19T00:00:00.000\\"]}", "history_dates": "{\\"name\\":\\"ds\\",\\"index\\":[0,1,2,3,4,5,6,7,8],\\"data\\":[\\"2020-10-01T00:00:00.000\\",\\"2020-10-04T00:00:00.000\\",\\"2020-10-07T00:00:00.000\\",\\"2020-10-10T00:00:00.000\\",\\"2020-10-13T00:00:00.000\\",\\"2020-10-16T00:00:00.000\\",\\"2020-10-19T00:00:00.000\\",\\"2020-10-22T00:00:00.000\\",\\"2020-10-25T00:00:00.000\\"]}", "train_holiday_names": null, "start": 1601510400.0, "t_scale": 2073600.0, "holidays": null, "history": "{\\"schema\\":{\\"fields\\":[{\\"name\\":\\"ds\\",\\"type\\":\\"datetime\\"},{\\"name\\":\\"y\\",\\"type\\":\\"integer\\"},{\\"name\\":\\"floor\\",\\"type\\":\\"integer\\"},{\\"name\\":\\"t\\",\\"type\\":\\"number\\"},{\\"name\\":\\"y_scaled\\",\\"type\\":\\"number\\"}],\\"pandas_version\\":\\"1.4.0\\"},\\"data\\":[{\\"ds\\":\\"2020-10-01T00:00:00.000\\",\\"y\\":0,\\"floor\\":0,\\"t\\":0.0,\\"y_scaled\\":0.0},{\\"ds\\":\\"2020-10-04T00:00:00.000\\",\\"y\\":1,\\"floor\\":0,\\"t\\":0.125,\\"y_scaled\\":0.125},{\\"ds\\":\\"2020-10-07T00:00:00.000\\",\\"y\\":2,\\"floor\\":0,\\"t\\":0.25,\\"y_scaled\\":0.25},{\\"ds\\":\\"2020-10-10T00:00:00.000\\",\\"y\\":3,\\"floor\\":0,\\"t\\":0.375,\\"y_scaled\\":0.375},{\\"ds\\":\\"2020-10-13T00:00:00.000\\",\\"y\\":4,\\"floor\\":0,\\"t\\":0.5,\\"y_scaled\\":0.5},{\\"ds\\":\\"2020-10-16T00:00:00.000\\",\\"y\\":5,\\"floor\\":0,\\"t\\":0.625,\\"y_scaled\\":0.625},{\\"ds\\":\\"2020-10-19T00:00:00.000\\",\\"y\\":6,\\"floor\\":0,\\"t\\":0.75,\\"y_scaled\\":0.75},{\\"ds\\":\\"2020-10-22T00:00:00.000\\",\\"y\\":7,\\"floor\\":0,\\"t\\":0.875,\\"y_scaled\\":0.875},{\\"ds\\":\\"2020-10-25T00:00:00.000\\",\\"y\\":8,\\"floor\\":0,\\"t\\":1.0,\\"y_scaled\\":1.0}]}", "train_component_cols": "{\\"schema\\":{\\"fields\\":[{\\"name\\":\\"additive_terms\\",\\"type\\":\\"integer\\"},{\\"name\\":\\"weekly\\",\\"type\\":\\"integer\\"},{\\"name\\":\\"multiplicative_terms\\",\\"type\\":\\"integer\\"}],\\"pandas_version\\":\\"1.4.0\\"},\\"data\\":[{\\"additive_terms\\":1,\\"weekly\\":1,\\"multiplicative_terms\\":0},{\\"additive_terms\\":1,\\"weekly\\":1,\\"multiplicative_terms\\":0},{\\"additive_terms\\":1,\\"weekly\\":1,\\"multiplicative_terms\\":0},{\\"additive_terms\\":1,\\"weekly\\":1,\\"multiplicative_terms\\":0},{\\"additive_terms\\":1,\\"weekly\\":1,\\"multiplicative_terms\\":0},{\\"additive_terms\\":1,\\"weekly\\":1,\\"multiplicative_terms\\":0}]}", "changepoints_t": [0.125, 0.25, 0.375, 0.5, 0.625, 0.75], "seasonalities": [["weekly"], {"weekly": {"period": 7, "fourier_order": 3, "prior_scale": 10.0, "mode": "additive", "condition_name": null}}], "extra_regressors": [[], {}], "fit_kwargs": {}, "params": {"lp__": [[202.053]], "k": [[1.19777]], "m": [[0.0565623]], "delta": [[-0.86152, 0.409957, -0.103241, 0.528979, 0.535181, -0.509356]], "sigma_obs": [[2.53056e-13]], "beta": [[-0.00630566, 0.016248, 0.0318587, -0.068705, 0.0029986, -0.00410522]], "trend": [[0.0565623, 0.206283, 0.248314, 0.341589, 0.421959, 0.568452, 0.781842, 0.931562, 1.08128]]}, "__prophet_version": "1.1.1"}'
 
+class BaseProphetModelTest(unittest.TestCase):
+    def _check_requirements(self, run_id: str):
+        # read requirements.txt from the run
+        requirements_path = mlflow.artifacts.download_artifacts(f"runs:/{run_id}/model/requirements.txt")
+        with open(requirements_path, "r") as f:
+            requirements = f.read()
+        # check if all additional dependencies are logged
+        for dependency in PROPHET_ADDITIONAL_PIP_DEPS:
+            self.assertIn(dependency, requirements, f"requirements.txt should contain {dependency} but got {requirements}")
 
-class TestProphetModel(unittest.TestCase):
+class TestProphetModel(BaseProphetModelTest):
     @classmethod
     def setUpClass(cls) -> None:
         num_rows = 9
@@ -74,8 +84,13 @@ class TestProphetModel(unittest.TestCase):
 
         with mlflow.start_run() as run:
             mlflow_prophet_log_model(prophet_model)
-        # Load the saved model from mlflow
+        
         run_id = run.info.run_id
+
+        # Check additonal requirements logged correctly
+        self._check_requirements(run_id)
+
+        # Load the saved model from mlflow
         prophet_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
 
         # Check the prediction with the saved model
@@ -144,7 +159,7 @@ class TestProphetModel(unittest.TestCase):
         assert e.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
 
 
-class TestMultiSeriesProphetModel(unittest.TestCase):
+class TestMultiSeriesProphetModel(BaseProphetModelTest):
     @classmethod
     def setUpClass(cls) -> None:
         cls.model_json = PROPHET_MODEL_JSON
@@ -178,8 +193,13 @@ class TestMultiSeriesProphetModel(unittest.TestCase):
         with mlflow.start_run() as run:
             mlflow_prophet_log_model(self.prophet_model, sample_input=test_df)
 
-        # Load the saved model from mlflow
+        
         run_id = run.info.run_id
+
+        # Check additonal requirements logged correctly
+        self._check_requirements(run_id)
+
+        # Load the saved model from mlflow
         loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
 
         # Check the prediction with the saved model
@@ -239,9 +259,13 @@ class TestMultiSeriesProphetModel(unittest.TestCase):
         )
         with mlflow.start_run() as run:
             mlflow_prophet_log_model(prophet_model, sample_input=test_df)
+ 
+        run_id = run.info.run_id
+
+        # Check additonal requirements logged correctly
+        self._check_requirements(run_id)
 
         # Load the saved model from mlflow
-        run_id = run.info.run_id
         loaded_model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
 
         # Check the prediction with the saved model

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -80,7 +80,7 @@ class TestProphetModel(BaseProphetModelTest):
         cls.model = model_from_json(cls.model_json)
 
     def test_model_save_and_load(self):
-        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds")
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds", )
 
         with mlflow.start_run() as run:
             mlflow_prophet_log_model(prophet_model)
@@ -178,6 +178,21 @@ class TestProphetModel(BaseProphetModelTest):
         with pytest.raises(MlflowException, match="Model is missing inputs") as e:
             prophet_model.predict(test_df)
         assert e.value.error_code == ErrorCode.Name(INTERNAL_ERROR)
+
+    def test_predict_with_preprocess_func(self):
+        def preprocess_func(df):
+            df["y"] = df["y"] * 2
+            return df
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds", "split", preprocess_func)
+        test_df = pd.DataFrame(
+            {
+                "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-04")], 
+                "split": ["train", "test"],
+                "y": [1, 2]
+            }
+        )
+        yhat = prophet_model.predict(None, test_df)
+        self.assertEqual(2, len(yhat))
 
 
 class TestMultiSeriesProphetModel(BaseProphetModelTest):
@@ -405,3 +420,34 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
     def test_make_future_dataframe_invalid_group(self):
         with pytest.raises(ValueError, match="Invalid groups:"):
             future_df = self.prophet_model.make_future_dataframe(groups=[(1,)])
+
+
+    def test_predict_with_preprocess_func(self):
+        def preprocess_func(df):
+            df["y"] = df["y"] + 1
+            return df
+        multi_series_model_json = {("1", ): self.model_json, ("2", ): self.model_json}
+        multi_series_start = {
+            (1, "1"): pd.Timestamp("2020-07-01"),
+            (2, "1"): pd.Timestamp("2020-07-01"),
+        }
+        prophet_model = MultiSeriesProphetModel(
+            multi_series_model_json,
+            multi_series_start, 
+            "2020-07-25",
+            1, 
+            "days", 
+            1, 
+            "ds", 
+            ["id"],
+            "split", 
+            preprocess_func)
+        test_df = pd.DataFrame(
+            {
+                "ds": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-02")], 
+                "split": ["train", "test"],
+                "id": ["1", "2"],
+            }
+        )
+        yhat = prophet_model.predict(None, test_df)
+        self.assertEqual(2, len(yhat))

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -15,6 +15,7 @@
 #
 
 import unittest
+from unittest.mock import patch
 import datetime
 
 import pandas as pd
@@ -103,6 +104,42 @@ class TestProphetModel(BaseProphetModelTest):
             include_history=False
         )
         self.assertEqual(len(forecast_future_pd), 1)
+    
+    @patch("databricks.automl_runtime.forecast.prophet.model.ProphetModel._predict_impl")
+    def test_predict_timeseries_with_preprocess_func(self, mock_predict_impl):
+        # Mock the output of _predict_impl
+        mock_predict_impl.side_effect = lambda df: df
+
+        # Define a preprocess function
+        def preprocess_func(df):
+            df["feature"] = df["feature"] * 2
+            return df
+
+        # Create a ProphetModel instance with preprocess_func
+        prophet_model = ProphetModel(
+            model_json=PROPHET_MODEL_JSON,
+            horizon=3,
+            frequency_unit="d",
+            frequency_quantity=1,
+            time_col="time",
+            preprocess_func=preprocess_func,
+            split_col="split"
+        )
+
+        # Input DataFrame
+        input_df = pd.DataFrame({"time": ["2020-10-01", "2020-10-02", "2020-10-03"], "feature": [1, 2, 3]})
+
+        # Call predict_timeseries
+        result = prophet_model.predict_timeseries(future_df=input_df)
+
+        # Assertions
+        mock_predict_impl.assert_called_once()
+        self.assertEqual(len(result), 3)
+
+        # Check if the preprocess_func was applied
+        processed_df = mock_predict_impl.call_args[0][0]  # Get the DataFrame passed to _predict_impl
+        self.assertTrue((processed_df["feature"] == [2, 4, 6]).all())  # Check if "y" was doubled
+        self.assertIn("ds", processed_df.columns)  # Ensure "ds" column exists
 
     def test_make_future_dataframe(self):
         for feq_unit in OFFSET_ALIAS_MAP:
@@ -451,3 +488,68 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
         )
         yhat = prophet_model.predict(None, test_df)
         self.assertEqual(2, len(yhat))
+
+    @patch("databricks.automl_runtime.forecast.prophet.model.MultiSeriesProphetModel._predict_impl")
+    def test_predict_timeseries(self, mock_predict_impl):
+        # Mock the output of _predict_impl
+        mock_predict_impl.side_effect = lambda df, horizon, include_history: pd.DataFrame({
+            "ds": df["ds"],
+            "feature": df["feature"],
+            "id": df["id"]
+        })
+
+        # Define a preprocess function
+        def preprocess_func(df):
+            df["feature"] = df["feature"] * 2
+            return df
+
+        # Create a MultiSeriesProphetModel instance
+        model_json = {
+            ("id1",): '{"model": "mock_model_1"}',
+            ("id2",): '{"model": "mock_model_2"}'
+        }
+        timeseries_starts = {("id1",): pd.Timestamp("2020-01-01"), ("id2",): pd.Timestamp("2020-01-01")}
+        timeseries_end = "2020-12-31"
+        prophet_model = MultiSeriesProphetModel(
+            model_json=model_json,
+            timeseries_starts=timeseries_starts,
+            timeseries_end=timeseries_end,
+            horizon=3,
+            frequency_unit="d",
+            frequency_quantity=1,
+            time_col="time",
+            id_cols=["id"],
+            preprocess_func=preprocess_func,
+            split_col="split"
+        )
+
+        # Input DataFrame
+        input_df = pd.DataFrame({
+            "time": ["2020-10-01", "2020-10-02", "2020-10-03", "2020-10-01", "2020-10-02", "2020-10-03"],
+            "feature": [1, 2, 3, 4, 5, 6],
+            "id": ["id1", "id1", "id1", "id2", "id2", "id2"]
+        })
+
+        # Call predict_timeseries
+        result = prophet_model.predict_timeseries(future_df=input_df)
+
+        # Assertions
+        mock_predict_impl.assert_called()
+        self.assertEqual(len(result), 6)
+        self.assertIn("feature", result.columns)
+        self.assertIn("ds", result.columns)
+        self.assertIn("id", result.columns)
+
+        # Check the calls to _predict_impl
+        calls = mock_predict_impl.call_args_list
+        self.assertEqual(len(calls), 2)  # Ensure _predict_impl is called twice (once per group)
+
+        # Check the first call
+        first_call_df = calls[0][0][0]  # Get the DataFrame passed in the first call
+        self.assertTrue((first_call_df["feature"] == [2, 4, 6]).all())
+        self.assertTrue((first_call_df["id"] == ["id1", "id1", "id1"]).all())
+
+        # Check the second call
+        second_call_df = calls[1][0][0]  # Get the DataFrame passed in the second call
+        self.assertTrue((second_call_df["feature"] == [8, 10, 12]).all())
+        self.assertTrue((second_call_df["id"] == ["id2", "id2", "id2"]).all())

--- a/runtime/tests/automl_runtime/forecast/prophet/model_test.py
+++ b/runtime/tests/automl_runtime/forecast/prophet/model_test.py
@@ -80,7 +80,7 @@ class TestProphetModel(BaseProphetModelTest):
         cls.model = model_from_json(cls.model_json)
 
     def test_model_save_and_load(self):
-        prophet_model = ProphetModel(self.model_json, 1, "d", "ds")
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds")
 
         with mlflow.start_run() as run:
             mlflow_prophet_log_model(prophet_model)
@@ -110,7 +110,7 @@ class TestProphetModel(BaseProphetModelTest):
             # don't have full support yet.
             if OFFSET_ALIAS_MAP[feq_unit] in ['YS', 'MS', 'QS']:
                 continue
-            prophet_model = ProphetModel(self.model_json, 1, feq_unit, "ds")
+            prophet_model = ProphetModel(self.model_json, 1, feq_unit, 1, "ds")
             future_df = prophet_model.make_future_dataframe(1)
             offset_kw_arg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP[feq_unit]]
             expected_time = pd.Timestamp("2020-10-25") + pd.DateOffset(**offset_kw_arg)
@@ -118,8 +118,18 @@ class TestProphetModel(BaseProphetModelTest):
                              f"Wrong future dataframe generated with frequency {feq_unit}:"
                              f" Expect {expected_time}, but get {future_df.iloc[-1]['ds']}")
 
+    def test_make_future_dataframe_with_multiple_frequency_quantities(self):
+        for frequency_quantity in [1, 5, 10, 15, 30]:
+            prophet_model = ProphetModel(self.model_json, 1, "min", frequency_quantity, "ds")
+            future_df = prophet_model.make_future_dataframe(1)
+            offset_kw_arg = DATE_OFFSET_KEYWORD_MAP[OFFSET_ALIAS_MAP["min"]]
+            expected_time = pd.Timestamp("2020-10-25") + pd.DateOffset(**offset_kw_arg)*frequency_quantity
+            self.assertEqual(future_df.iloc[-1]["ds"], expected_time,
+                             f"Wrong future dataframe generated with frequency min:"
+                             f" Expect {expected_time}, but get {future_df.iloc[-1]['ds']}")
+
     def test_predict_success_datetime_date(self):
-        prophet_model = ProphetModel(self.model_json, 1, "d", "ds")
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds")
         test_df = pd.DataFrame(
             {"ds": [datetime.date(2020, 10, 8), datetime.date(2020, 12, 10)]}
         )
@@ -131,7 +141,7 @@ class TestProphetModel(BaseProphetModelTest):
         )  # check the input dataframe is unchanged
 
     def test_predict_success_string(self):
-        prophet_model = ProphetModel(self.model_json, 1, "d", "ds")
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "ds")
         test_df = pd.DataFrame({"ds": ["2020-10-08", "2020-12-10"]})
         expected_test_df = test_df.copy()
         yhat = prophet_model.predict(None, test_df)
@@ -140,8 +150,19 @@ class TestProphetModel(BaseProphetModelTest):
             test_df, expected_test_df
         )  # check the input dataframe is unchanged
 
+    def test_predict_multiple_frequency_quantities(self):
+        for frequency_quantity in [1, 5, 10, 15, 30]:
+            prophet_model = ProphetModel(self.model_json, 1, "min", frequency_quantity, "ds")
+            test_df = pd.DataFrame({"ds": ["2020-10-08", "2020-12-10"]})
+            expected_test_df = test_df.copy()
+            yhat = prophet_model.predict(None, test_df)
+            self.assertEqual(2, len(yhat))
+            pd.testing.assert_frame_equal(
+                test_df, expected_test_df
+            )  # check the input dataframe is unchanged
+
     def test_validate_predict_cols(self):
-        prophet_model = ProphetModel(self.model_json, 1, "d", "time")
+        prophet_model = ProphetModel(self.model_json, 1, "d", 1, "time")
         test_df = pd.DataFrame(
             {
                 "date": [pd.to_datetime("2020-11-01"), pd.to_datetime("2020-11-04")],
@@ -173,7 +194,8 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
             timeseries_starts=cls.multi_series_start,
             timeseries_end="2020-07-25",
             horizon=1,
-            frequency="days",
+            frequency_unit="days",
+            frequency_quantity=1,
             time_col="time",
             id_cols=["id"],
         )
@@ -241,6 +263,7 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
             "2020-07-25",
             1,
             "days",
+            1,
             "time",
             ["id1", "id2"],
         )
@@ -302,7 +325,8 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
             timeseries_starts=self.multi_series_start,
             timeseries_end="2020-07-25",
             horizon=1,
-            frequency="days",
+            frequency_unit="days",
+            frequency_quantity=1,
             time_col="ds",
             id_cols=["id1"],
         )
@@ -338,6 +362,23 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
         self.assertCountEqual(future_df.columns, {"ds", "id"})
         self.assertEqual(2, future_df.shape[0])
 
+    def test_make_future_dataframe_multiple_frequency_quantities(self):
+
+        for frequency_quantity in [1, 5, 10, 15, 30]:
+            prophet_model = MultiSeriesProphetModel(
+                model_json=self.multi_series_model_json,
+                timeseries_starts=self.multi_series_start,
+                timeseries_end="2020-07-25",
+                horizon=1,
+                frequency_unit="min",
+                frequency_quantity=frequency_quantity,
+                time_col="time",
+                id_cols=["id"],
+            )
+            future_df = prophet_model.make_future_dataframe(include_history=False)
+            self.assertCountEqual(future_df.columns, {"ds", "id"})
+            self.assertEqual(2, future_df.shape[0])
+
     def test_make_future_dataframe_multi_ids(self):
         multi_series_model_json = {(1, "1"): self.model_json, (2, "1"): self.model_json}
         multi_series_start = {
@@ -350,6 +391,7 @@ class TestMultiSeriesProphetModel(BaseProphetModelTest):
             "2020-07-25",
             1,
             "days",
+            1,
             "time",
             ["id1", "id2"],
         )

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -131,11 +131,11 @@ class TestGenerateCutoffs(unittest.TestCase):
         ).rename_axis("y").reset_index()
 
     def test_generate_cutoffs_success(self):
-        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", num_folds=3, seasonal_period=7)
+        cutoffs = generate_cutoffs(self.X, horizon=7, frequency_unit="D", num_folds=3, seasonal_period=7)
         self.assertEqual([pd.Timestamp('2020-08-16 00:00:00'), pd.Timestamp('2020-08-19 12:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_success_large_num_folds(self):
-        cutoffs = generate_cutoffs(self.X, horizon=7, unit="D", num_folds=20, seasonal_period=1)
+        cutoffs = generate_cutoffs(self.X, horizon=7, frequency_unit="D", num_folds=20, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2020-07-22 12:00:00'),
                           pd.Timestamp('2020-07-26 00:00:00'),
                           pd.Timestamp('2020-07-29 12:00:00'),
@@ -151,7 +151,7 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=30, freq='3d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=1, unit="D", num_folds=5, seasonal_period=1)
+        cutoffs = generate_cutoffs(df, horizon=1, frequency_unit="D", num_folds=5, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2020-09-13 00:00:00'),
                           pd.Timestamp('2020-09-16 00:00:00'),
                           pd.Timestamp('2020-09-19 00:00:00'),
@@ -167,10 +167,10 @@ class TestGenerateCutoffs(unittest.TestCase):
                             pd.Timestamp('2020-07-07 11:00:00'),
                             pd.Timestamp('2020-07-07 14:00:00'),
                             pd.Timestamp('2020-07-07 17:00:00')]
-        cutoffs = generate_cutoffs(df, horizon=6, unit="H", num_folds=5, seasonal_period=24)
+        cutoffs = generate_cutoffs(df, horizon=6, frequency_unit="H", num_folds=5, seasonal_period=24)
         self.assertEqual(expected_cutoffs, cutoffs)
 
-        cutoffs_different_seasonal_unit = generate_cutoffs(df, horizon=6, unit="H", num_folds=5,
+        cutoffs_different_seasonal_unit = generate_cutoffs(df, horizon=6, frequency_unit="H", num_folds=5,
                                                            seasonal_period=1, seasonal_unit="D")
         self.assertEqual(expected_cutoffs, cutoffs_different_seasonal_unit)
 
@@ -178,39 +178,63 @@ class TestGenerateCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=52, freq='W'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=4, unit="W", num_folds=3, seasonal_period=1)
+        cutoffs = generate_cutoffs(df, horizon=4, frequency_unit="W", num_folds=3, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2021-05-02 00:00:00'), pd.Timestamp('2021-05-16 00:00:00'), pd.Timestamp('2021-05-30 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_failure_horizon_too_large(self):
         with self.assertRaisesRegex(ValueError, "Less data than horizon after initial window. "
                                                 "Make horizon shorter."):
-            generate_cutoffs(self.X, horizon=20, unit="D", num_folds=3, seasonal_period=1)
+            generate_cutoffs(self.X, horizon=20, frequency_unit="D", num_folds=3, seasonal_period=1)
 
     def test_generate_cutoffs_less_data(self):
         with self.assertRaisesRegex(ValueError, "Less data than horizon."):
-            generate_cutoffs(self.X, horizon=100, unit="D", num_folds=3, seasonal_period=1)
+            generate_cutoffs(self.X, horizon=100, frequency_unit="D", num_folds=3, seasonal_period=1)
 
     def test_generate_cutoffs_success_monthly(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-01-12", periods=24, freq=pd.DateOffset(months=1)), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=2, unit="MS", num_folds=3, seasonal_period=1)
+        cutoffs = generate_cutoffs(df, horizon=2, frequency_unit="MS", num_folds=3, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2021-08-12 00:00:00'), pd.Timestamp('2021-9-12 00:00:00'), pd.Timestamp('2021-10-12 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_success_quaterly(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-12", periods=9, freq=pd.DateOffset(months=3)), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=1, unit="QS", num_folds=3, seasonal_period=1)
+        cutoffs = generate_cutoffs(df, horizon=1, frequency_unit="QS", num_folds=3, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2021-10-12 00:00:00'), pd.Timestamp('2022-01-12 00:00:00'), pd.Timestamp('2022-04-12 00:00:00')], cutoffs)
 
     def test_generate_cutoffs_success_annualy(self):
         df = pd.DataFrame(
             pd.date_range(start="2012-07-14", periods=10, freq=pd.DateOffset(years=1)), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_cutoffs(df, horizon=1, unit="YS", num_folds=3, seasonal_period=1)
+        cutoffs = generate_cutoffs(df, horizon=1, frequency_unit="YS", num_folds=3, seasonal_period=1)
         self.assertEqual([pd.Timestamp('2018-07-14 00:00:00'), pd.Timestamp('2019-07-14 00:00:00'), pd.Timestamp('2020-07-14 00:00:00')], cutoffs)
 
+    def test_generate_cutoffs_success_with_multiple_frequency_quantities(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:55:00", freq='5T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_cutoffs(df, horizon=1, frequency_unit="min", num_folds=3, seasonal_period=1)
+        self.assertEqual([pd.Timestamp('2020-07-01 23:44:00'), pd.Timestamp('2020-07-01 23:49:00'), pd.Timestamp('2020-07-01 23:54:00')], cutoffs)
+
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:50:00", freq='10T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_cutoffs(df, horizon=1, frequency_unit="min", num_folds=3, seasonal_period=1)
+        self.assertEqual([pd.Timestamp('2020-07-01 23:29:00'), pd.Timestamp('2020-07-01 23:39:00'), pd.Timestamp('2020-07-01 23:49:00')], cutoffs)
+
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:45:00", freq='15T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_cutoffs(df, horizon=1, frequency_unit="min", num_folds=3, seasonal_period=1)
+        self.assertEqual([pd.Timestamp('2020-07-01 23:14:00'), pd.Timestamp('2020-07-01 23:29:00'), pd.Timestamp('2020-07-01 23:44:00')], cutoffs)
+
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:30:00", freq='30T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_cutoffs(df, horizon=1, frequency_unit="min", num_folds=3, seasonal_period=1)
+        self.assertEqual([pd.Timestamp('2020-07-01 22:29:00'), pd.Timestamp('2020-07-01 22:59:00'), pd.Timestamp('2020-07-01 23:29:00')], cutoffs)
 
 class TestTestGenerateCustomCutoffs(unittest.TestCase):
 
@@ -222,56 +246,81 @@ class TestTestGenerateCustomCutoffs(unittest.TestCase):
                             pd.Timestamp('2020-07-07 14:00:00'),
                             pd.Timestamp('2020-07-07 15:00:00'),
                             pd.Timestamp('2020-07-07 16:00:00')]
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="H", split_cutoff=pd.Timestamp('2020-07-07 13:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="H", split_cutoff=pd.Timestamp('2020-07-07 13:00:00'))
         self.assertEqual(expected_cutoffs, cutoffs)
 
     def test_generate_custom_cutoffs_success_daily(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", end="2020-08-30", freq='d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-08-21 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="D", split_cutoff=pd.Timestamp('2020-08-21 00:00:00'))
         self.assertEqual([pd.Timestamp('2020-08-21 00:00:00'), pd.Timestamp('2020-08-22 00:00:00'), pd.Timestamp('2020-08-23 00:00:00')], cutoffs)
     
     def test_generate_custom_cutoffs_success_small_horizon(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", end="2020-08-30", freq='2d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=1, unit="D", split_cutoff=pd.Timestamp('2020-08-26 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=1, frequency_unit="D", split_cutoff=pd.Timestamp('2020-08-26 00:00:00'))
         self.assertEqual([pd.Timestamp('2020-08-27 00:00:00'), pd.Timestamp('2020-08-29 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_weekly(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=52, freq='W'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="W", split_cutoff=pd.Timestamp('2021-04-25 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="W", split_cutoff=pd.Timestamp('2021-04-25 00:00:00'))
         self.assertEqual([pd.Timestamp('2021-04-25 00:00:00'), pd.Timestamp('2021-05-02 00:00:00'), pd.Timestamp('2021-05-09 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_monthly(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-01-12", periods=24, freq=pd.DateOffset(months=1)), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="MS", split_cutoff=pd.Timestamp('2021-03-12 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="MS", split_cutoff=pd.Timestamp('2021-03-12 00:00:00'))
         self.assertEqual([pd.Timestamp('2021-03-12 00:00:00'), pd.Timestamp('2021-04-12 00:00:00'), pd.Timestamp('2021-05-12 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_quaterly(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-12", periods=9, freq=pd.DateOffset(months=3)), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="QS", split_cutoff=pd.Timestamp('2020-07-12 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="QS", split_cutoff=pd.Timestamp('2020-07-12 00:00:00'))
         self.assertEqual([pd.Timestamp('2020-07-12 00:00:00'), pd.Timestamp('2020-10-12 00:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_annualy(self):
         df = pd.DataFrame(
             pd.date_range(start="2012-07-14", periods=10, freq=pd.DateOffset(years=1)), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="YS", split_cutoff=pd.Timestamp('2012-07-14 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="YS", split_cutoff=pd.Timestamp('2012-07-14 00:00:00'))
         self.assertEqual([pd.Timestamp('2012-07-14 00:00:00'), pd.Timestamp('2013-07-14 00:00:00'), pd.Timestamp('2014-07-14 00:00:00')], cutoffs)
+
+    def test_generate_custom_cutoffs_success_with_multiple_frequency_quantities(self):
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:55:00", freq='5T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=1, frequency_unit="min", frequency_quantity=5, split_cutoff=pd.Timestamp('2020-07-01 23:45:00'))
+        self.assertEqual([pd.Timestamp('2020-07-01 23:45:00'), pd.Timestamp('2020-07-01 23:50:00')], cutoffs)
+
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:50:00", freq='10T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=1, frequency_unit="min", frequency_quantity=10, split_cutoff=pd.Timestamp('2020-07-01 23:30:00'))
+        self.assertEqual([pd.Timestamp('2020-07-01 23:30:00'), pd.Timestamp('2020-07-01 23:40:00')], cutoffs)
+
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:45:00", freq='15T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=1, frequency_unit="min", frequency_quantity=15, split_cutoff=pd.Timestamp('2020-07-01 23:15:00'))
+        self.assertEqual([pd.Timestamp('2020-07-01 23:15:00'), pd.Timestamp('2020-07-01 23:30:00')], cutoffs)
+
+        df = pd.DataFrame(
+            pd.date_range(start="2020-07-01 00:00:00", end="2020-07-01 23:30:00", freq='30T'), columns=["ds"]
+        ).rename_axis("y").reset_index()
+        cutoffs = generate_custom_cutoffs(df, horizon=1, frequency_unit="min", frequency_quantity=30, split_cutoff=pd.Timestamp('2020-07-01 23:00:00'))
+        self.assertEqual([pd.Timestamp('2020-07-01 23:00:00')], cutoffs)
 
     def test_generate_custom_cutoffs_success_with_small_gaps(self):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=30, freq='3d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2020-09-17 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="D", split_cutoff=pd.Timestamp('2020-09-17 00:00:00'))
         self.assertEqual([pd.Timestamp('2020-09-17 00:00:00'),
                           pd.Timestamp('2020-09-18 00:00:00'),
                           pd.Timestamp('2020-09-19 00:00:00')], cutoffs)
@@ -280,7 +329,7 @@ class TestTestGenerateCustomCutoffs(unittest.TestCase):
         df = pd.DataFrame(
             pd.date_range(start="2020-07-01", periods=30, freq='9d'), columns=["ds"]
         ).rename_axis("y").reset_index()
-        cutoffs = generate_custom_cutoffs(df, horizon=7, unit="D", split_cutoff=pd.Timestamp('2021-03-08 00:00:00'))
+        cutoffs = generate_custom_cutoffs(df, horizon=7, frequency_unit="D", split_cutoff=pd.Timestamp('2021-03-08 00:00:00'))
         self.assertEqual([pd.Timestamp('2021-03-08 00:00:00'),
                           pd.Timestamp('2021-03-09 00:00:00'),
                           pd.Timestamp('2021-03-12 00:00:00')], cutoffs)
@@ -300,7 +349,7 @@ class TestCalculatePeriodsAndFrequency(unittest.TestCase):
             )
         })
         periods = df.apply(lambda x: calculate_period_differences(
-            x.start_time, x.end_time, 'month'
+            x.start_time, x.end_time, 'month', 1
         ), axis=1)
         self.assertTrue((periods == pd.Series([4, 5, 12])).all())
     
@@ -314,13 +363,24 @@ class TestCalculatePeriodsAndFrequency(unittest.TestCase):
             )
         })
         periods = df.apply(lambda x: calculate_period_differences(
-            x.start_time, x.end_time, 'month'
+            x.start_time, x.end_time, 'month', 1
         ), axis=1)
         self.assertTrue((periods == pd.Series([4, 5, 0])).all())
         periods = df.apply(lambda x: calculate_period_differences(
-            x.start_time, x.end_time, 'day'
+            x.start_time, x.end_time, 'day', 1
         ), axis=1)
         self.assertTrue((periods == pd.Series([118, 151, 0])).all())
+    
+    def test_calculate_period_differences_with_frequency_quantity(self):
+        for frequency_quantity in [1, 5, 10, 15, 30]:
+            df = pd.DataFrame({
+                'start_time': pd.date_range(start="2020-07-01 00:00:00", periods=10, freq=f'{frequency_quantity}T'),
+                'end_time': pd.date_range(start="2020-07-01 04:00:00", periods=10, freq=f'{frequency_quantity}T')
+            })
+            periods = df.apply(lambda x: calculate_period_differences(
+                x.start_time, x.end_time, 'min', frequency_quantity
+            ), axis=1)
+            self.assertTrue((periods == pd.Series([240//frequency_quantity]*10)).all())
 
     def test_frequency_consistency(self):
         start_time = pd.Series(
@@ -331,13 +391,24 @@ class TestCalculatePeriodsAndFrequency(unittest.TestCase):
         )
         start_scalar = pd.to_datetime('2021-01-14')
         end_scalar = pd.to_datetime('2021-05-16')
-        self.assertFalse(is_frequency_consistency(start_scalar, end_scalar, 'month'))
+        self.assertFalse(is_frequency_consistency(start_scalar, end_scalar, 'month', 1))
         self.assertTrue(start_time.apply(
-            lambda x: is_frequency_consistency(x, end_scalar, 'day')
+            lambda x: is_frequency_consistency(x, end_scalar, 'day', 1)
         ).all())
         self.assertTrue(end_time.apply(
-            lambda x: is_frequency_consistency(start_scalar, x, 'month')
+            lambda x: is_frequency_consistency(start_scalar, x, 'month', 1)
         ).all())
+
+    def test_frequency_consistency_with_frequency_quantity(self):
+        for frequency_quantity in [1, 5, 10, 15, 30]:
+            start_time = pd.date_range(start="2020-07-01 00:00:00", periods=10, freq=f'{frequency_quantity}T')
+            end_time = pd.date_range(start="2020-07-01 04:00:00", periods=10, freq=f'{frequency_quantity}T')
+            self.assertTrue(start_time.to_series().apply(
+                lambda x: is_frequency_consistency(x, end_time[0], 'min', frequency_quantity)
+            ).all())
+            self.assertTrue(end_time.to_series().apply(
+                lambda x: is_frequency_consistency(start_time[0], x, 'min', frequency_quantity)
+            ).all())
 
 
 class TestMakeFutureDataFrame(unittest.TestCase):
@@ -346,7 +417,8 @@ class TestMakeFutureDataFrame(unittest.TestCase):
             start_time=pd.to_datetime('2022-01-01'),
             end_time=pd.to_datetime('2022-01-04'),
             horizon=1,
-            frequency="d",
+            frequency_unit="d",
+            frequency_quantity=1,
             include_history=False,
             column_name="test_date"
         )
@@ -358,7 +430,8 @@ class TestMakeFutureDataFrame(unittest.TestCase):
             start_time=pd.to_datetime('2022-01-01'),
             end_time=pd.to_datetime('2022-01-04'),
             horizon=1,
-            frequency="d",
+            frequency_unit="d",
+            frequency_quantity=1,
             include_history=True,
             column_name="test_date"
         )
@@ -374,7 +447,25 @@ class TestMakeFutureDataFrame(unittest.TestCase):
                 start_time=start_time,
                 end_time=end_time,
                 horizon=1,
-                frequency=freq,
+                frequency_unit=freq,
+                frequency_quantity=1,
+                include_history=True,
+                column_name="test_date"
+            )
+            self.assertEqual(len(future_df), 3)
+            expected_columns = { "test_date" }
+            self.assertTrue(expected_columns.issubset(set(future_df.columns)))
+
+    def test_make_single_future_dataframe_with_different_frequency_quantities(self):
+        for frequency_quantity in [1, 5, 10, 15, 30]:
+            start_time = pd.to_datetime('2022-01-01')
+            end_time = start_time + pd.DateOffset(**{'minutes': 1}) * frequency_quantity
+            future_df = make_single_future_dataframe(
+                start_time=start_time,
+                end_time=end_time,
+                horizon=1,
+                frequency_unit="min",
+                frequency_quantity=frequency_quantity,
                 include_history=True,
                 column_name="test_date"
             )
@@ -383,24 +474,31 @@ class TestMakeFutureDataFrame(unittest.TestCase):
             self.assertTrue(expected_columns.issubset(set(future_df.columns)))
 
     @parameterized.expand([
-        (pd.to_datetime('2022-01-01'), pd.to_datetime('2022-01-05'), None, None, { "ds" }, ),
-        (pd.to_datetime('2022-01-01'), pd.to_datetime('2022-01-05'), ["id"], [("1", )], { "ds", "id" }),
+        (pd.to_datetime('2022-01-01'), pd.to_datetime('2022-01-05'), None, None, { "ds" }, "d", 1),
+        (pd.to_datetime('2022-01-01'), pd.to_datetime('2022-01-05'), ["id"], [("1", )], { "ds", "id" }, "d", 1),
         (pd.to_datetime('2022-01-01'), pd.to_datetime('2022-01-05'), ["id1", "id2"],
-         [("1", 1)], { "ds", "id1", "id2" }),
+         [("1", 1)], { "ds", "id1", "id2" }, "d", 1),
         ({("1", ): pd.to_datetime('2022-01-01'), ("2", ): pd.to_datetime('2022-01-01')},
-         pd.to_datetime('2022-01-02'), ["id"], [("1", ), ("2", )], { "ds", "id" }),
+         pd.to_datetime('2022-01-02'), ["id"], [("1", ), ("2", )], { "ds", "id" }, "d", 1),
         ({("1", ): pd.to_datetime('2022-01-01'), ("2", ): pd.to_datetime('2022-01-01')},
          {("1", ): pd.to_datetime('2022-01-02'), ("2", ): pd.to_datetime('2022-01-02')},
-         ["id"], [("1", ), ("2", )], { "ds", "id" }),
+         ["id"], [("1", ), ("2", )], { "ds", "id" }, "d", 1),
+        (pd.Timestamp('2022-01-01 00:00:00'), pd.Timestamp('2022-01-01 00:20:00'), None, None, { "ds" }, "min", 5),
+        (pd.Timestamp('2022-01-01 00:00:00'), pd.Timestamp('2022-01-01 00:40:00'), None, None, { "ds" }, "min", 10),
+        (pd.Timestamp('2022-01-01 00:00:00'), pd.Timestamp('2022-01-01 01:00:00'), None, None, { "ds" }, "min", 15),
+        (pd.Timestamp('2022-01-01 00:00:00'), pd.Timestamp('2022-01-01 02:00:00'), None, None, { "ds" }, "min", 30),
     ])
     def test_make_future_dataframe(self, start_time, end_time,
                                    identity_column_names,
-                                   groups, expected_columns):
+                                   groups, expected_columns,
+                                   frequency_unit,
+                                   frequency_quantity):
         future_df = make_future_dataframe(
             start_time=start_time,
             end_time=end_time,
             horizon=1,
-            frequency="d",
+            frequency_unit=frequency_unit,
+            frequency_quantity=frequency_quantity,
             groups=groups,
             identity_column_names=identity_column_names,
         )

--- a/runtime/tests/automl_runtime/forecast/utils_test.py
+++ b/runtime/tests/automl_runtime/forecast/utils_test.py
@@ -88,6 +88,40 @@ class TestGetValidationHorizon(unittest.TestCase):
             validation_horizon = get_validation_horizon(df, 10, "D")
             self.assertIn("too long relative to dataframe's timedelta. Validation horizon will be reduced to", cm.output[0])
 
+    def test_frequency_quantity(self):
+        # Since we only add extra supports of 5 min, 10 min, 15 min and 30 min for now, only test cases are added.
+        # We need to add more test cases when we add more supports.
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 23:55:00", freq="5T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 5)
+        self.assertEqual(validation_horizon, 10)
+
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 02:00:00", freq="5T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 5)
+        self.assertEqual(validation_horizon, 6)
+
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 23:45:00", freq="10T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 10)
+        self.assertEqual(validation_horizon, 10)
+
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 02:00:00", freq="10T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 10)
+        self.assertEqual(validation_horizon, 3)
+
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 23:45:00", freq="15T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 15)
+        self.assertEqual(validation_horizon, 10)
+
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 02:00:00", freq="15T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 15)
+        self.assertEqual(validation_horizon, 2)
+
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 23:45:00", freq="30T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 30)
+        self.assertEqual(validation_horizon, 10)
+
+        df = pd.DataFrame(pd.date_range(start="2020-08-01 00:00:00", end="2020-08-01 02:00:00", freq="30T"), columns=["ds"])
+        validation_horizon = get_validation_horizon(df, 10, "min", 30)
+        self.assertEqual(validation_horizon, 1)
 
 class TestGenerateCutoffs(unittest.TestCase):
 


### PR DESCRIPTION
Add category_encoders to model dependency so that loading the model that includes the input pipeline in batch inference notebook will not error out.