### PR TITLE
Add setuptools to lock file

### DIFF
--- a/runtime/environment.lock.txt
+++ b/runtime/environment.lock.txt
@@ -482,5 +482,5 @@ zipp==3.23.0
     #   importlib-metadata
     #   importlib-resources
 
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+setuptools<68
+    # added manually


### PR DESCRIPTION
Previously, setuptools was omitted from lock file as it was "unsafe". However, as our CI pipelines work on a consistent version of python, it is fine to pin it as well.